### PR TITLE
rmm: Apply clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
         cd rmm && cargo fmt -- --check && cd -
         cd plat/fvp && cargo fmt -- --check
 
+    - name: Check clippy lints
+      run: ./scripts/clippy.sh
+
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -3,7 +3,7 @@ use crate::bits_in_reg;
 define_sys_register!(
     MPIDR_EL1,     // ref. D7.2.74
     AFF2[23 - 16], // Affinity level 2
-    AFF1[15 - 08]  // Affinity level 1
+    AFF1[15 - 8]   // Affinity level 1
 );
 
 define_sys_register!(CurrentEL, EL[3 - 2]);
@@ -20,7 +20,7 @@ define_sys_register!(
     // Instruction Length for synchronous exceptions.
     IL[25 - 25],
     // Syndrome information.
-    ISS[24 - 00]
+    ISS[24 - 0]
 );
 
 define_bits!(
@@ -30,7 +30,7 @@ define_bits!(
     // Instruction Length for synchronous exceptions.
     IL[25 - 25],
     // Syndrome information.
-    ISS[24 - 00]
+    ISS[24 - 0]
 );
 
 define_sys_register!(
@@ -40,8 +40,8 @@ define_sys_register!(
     // Instruction Length for synchronous exceptions.
     IL[25 - 25],
     // Instruction Specific Syndrome.
-    ISS[24 - 00],
-    ISS_BRK_CMT[15 - 00],
+    ISS[24 - 0],
+    ISS_BRK_CMT[15 - 0],
     S1PTW[7 - 7],
     DFSC[5 - 0]
 );
@@ -158,17 +158,17 @@ define_sys_register!(
     TWI[13 - 13], // Traps WFI instruction
     DC[12 - 12],  // Default cacheable
     BSU[11 - 10], // Barrier shareability upgrade
-    FB[09 - 09],  // Forces broadcast
-    VSE[08 - 08], // Virtual System Error/Asynchronous Abort.
-    VI[07 - 07],  // Virtual IRQ interrupt
-    VF[06 - 06],  // Virtual FRQ interrupt
-    AMO[05 - 05], // Asynchronous abort and error interrupt routing
-    IMO[04 - 04], // Physical IRQ routing
-    FMO[03 - 03], // Physical FIQ routing
-    PTW[02 - 02], // Protected Table Walk
-    SWIO[01 - 01],
-    VM[00 - 00],             // Virtualization enable
-    RES0[63 - 34 | 29 - 29]  //RES1[01 - 01]
+    FB[9 - 9],    // Forces broadcast
+    VSE[8 - 8],   // Virtual System Error/Asynchronous Abort.
+    VI[7 - 7],    // Virtual IRQ interrupt
+    VF[6 - 6],    // Virtual FRQ interrupt
+    AMO[5 - 5],   // Asynchronous abort and error interrupt routing
+    IMO[4 - 4],   // Physical IRQ routing
+    FMO[3 - 3],   // Physical FIQ routing
+    PTW[2 - 2],   // Protected Table Walk
+    SWIO[1 - 1],
+    VM[0 - 0],               // Virtualization enable
+    RES0[63 - 34 | 29 - 29]  //RES1[1 - 1]
 );
 
 define_sys_register!(
@@ -190,9 +190,9 @@ define_sys_register!(
     TGran16[23 - 20],
     BigEndEL0[19 - 16],
     SNSMem[15 - 12],
-    BigEnd[11 - 08],
-    ASIDBits[07 - 04],
-    PARange[03 - 00]
+    BigEnd[11 - 8],
+    ASIDBits[7 - 4],
+    PARange[3 - 0]
 );
 
 define_sys_register!(

--- a/lib/vmsa/src/guard.rs
+++ b/lib/vmsa/src/guard.rs
@@ -37,13 +37,13 @@ impl<'a, E> Deref for EntryGuard<'a, E> {
     type Target = E;
 
     fn deref(&self) -> &Self::Target {
-        &*self.inner
+        &self.inner
     }
 }
 
 impl<'a, E> DerefMut for EntryGuard<'a, E> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut *self.inner
+        &mut self.inner
     }
 }
 

--- a/lib/vmsa/src/page.rs
+++ b/lib/vmsa/src/page.rs
@@ -49,7 +49,7 @@ impl<S: PageSize, A: Address> Page<S, A> {
         assert!(first.addr <= last.addr);
         PageIter {
             current: first,
-            last: last,
+            last,
         }
     }
 

--- a/lib/vmsa/src/page_table.rs
+++ b/lib/vmsa/src/page_table.rs
@@ -6,7 +6,6 @@ use super::guard::EntryGuard;
 use super::page::{Page, PageIter, PageSize};
 
 use alloc::alloc::Layout;
-
 use core::marker::PhantomData;
 
 // Safety/TODO:

--- a/rmm/src/exception/trap/syndrome.rs
+++ b/rmm/src/exception/trap/syndrome.rs
@@ -71,7 +71,7 @@ impl From<u32> for Syndrome {
             }
             0b10_0110 => Syndrome::SPAlignmentFault,
             0b11_1100 => Syndrome::Brk((origin & ESR_EL2::ISS_BRK_CMT as u32) as u16),
-            ec => Syndrome::Other(ec as u32),
+            ec => Syndrome::Other(ec),
         }
     }
 }

--- a/rmm/src/gic.rs
+++ b/rmm/src/gic.rs
@@ -218,16 +218,16 @@ pub fn save_state(vcpu: &mut VCPU<Context>) {
     let nr_aprs = GIC_FEATURES.nr_aprs;
 
     for i in 0..=nr_lrs {
-        *&mut gic_state.ich_lr_el2[i] = get_lr(i);
+        gic_state.ich_lr_el2[i] = get_lr(i);
     }
     for i in 0..=nr_aprs {
-        *&mut gic_state.ich_ap0r_el2[i] = get_ap0r(i);
-        *&mut gic_state.ich_ap1r_el2[i] = get_ap1r(i);
+        gic_state.ich_ap0r_el2[i] = get_ap0r(i);
+        gic_state.ich_ap1r_el2[i] = get_ap1r(i);
     }
 
-    *&mut gic_state.ich_vmcr_el2 = unsafe { ICH_VMCR_EL2.get() };
-    *&mut gic_state.ich_hcr_el2 = unsafe { ICH_HCR_EL2.get() };
-    *&mut gic_state.ich_misr_el2 = unsafe { ICH_MISR_EL2.get() };
+    gic_state.ich_vmcr_el2 = unsafe { ICH_VMCR_EL2.get() };
+    gic_state.ich_hcr_el2 = unsafe { ICH_HCR_EL2.get() };
+    gic_state.ich_misr_el2 = unsafe { ICH_MISR_EL2.get() };
 
     unsafe { ICH_HCR_EL2.set(gic_state.ich_hcr_el2 & !ICH_HCR_EL2_EN_BIT) };
 }
@@ -258,8 +258,7 @@ pub fn send_state_to_host(id: usize, vcpu: usize, run: &mut Run) -> Result<(), E
     let gic_state = &mut vcpu.lock().context.gic_state;
     let nr_lrs = GIC_FEATURES.nr_lrs;
 
-    (&mut unsafe { run.exit_gic_lrs_mut() }[..nr_lrs])
-        .copy_from_slice(&gic_state.ich_lr_el2[..nr_lrs]);
+    (unsafe { run.exit_gic_lrs_mut() }[..nr_lrs]).copy_from_slice(&gic_state.ich_lr_el2[..nr_lrs]);
     unsafe {
         run.set_gic_misr(gic_state.ich_misr_el2);
         run.set_gic_vmcr(gic_state.ich_vmcr_el2);

--- a/rmm/src/granule/entry.rs
+++ b/rmm/src/granule/entry.rs
@@ -167,7 +167,7 @@ impl Inner {
 
     pub fn check_parent(&self, parent: &Inner) -> Result<(), Error> {
         if let Some(src_parent) = &self.granule.parent {
-            if src_parent as *const Inner == parent as *const Inner {
+            if core::ptr::eq(src_parent, parent) {
                 Ok(())
             } else {
                 Err(Error::MmStateError)

--- a/rmm/src/host/mod.rs
+++ b/rmm/src/host/mod.rs
@@ -42,7 +42,7 @@ pub struct DataPage([u8; GRANULE_SIZE]);
 
 impl DataPage {
     pub unsafe fn as_ptr(&self) -> *const u8 {
-        self.0.as_ptr() as *const u8
+        self.0.as_ptr()
     }
 
     pub unsafe fn as_mut_ptr(&mut self) -> *mut u8 {
@@ -56,9 +56,7 @@ impl DataPage {
 
 impl Default for DataPage {
     fn default() -> Self {
-        Self {
-            0: [0; GRANULE_SIZE],
-        }
+        Self([0; GRANULE_SIZE])
     }
 }
 

--- a/rmm/src/host/pointer.rs
+++ b/rmm/src/host/pointer.rs
@@ -21,7 +21,7 @@ impl<T: HostAccessor> Pointer<T> {
     ///   (2) T::validate():  this function is used to validate each field in T. (e.g., a constraint on parameter value)
     /// It returns a guard object only if it passes the two steps.
     #[inline]
-    pub fn acquire<'a>(&'a self) -> Option<PointerGuard<'a, T>> {
+    pub fn acquire(&self) -> Option<PointerGuard<'_, T>> {
         if T::acquire(self.ptr as usize) {
             let guard = PointerGuard { inner: self };
             if !guard.validate() {
@@ -80,7 +80,7 @@ impl<T: HostAccessor> PointerMut<T> {
     }
 
     #[inline]
-    pub fn acquire<'a>(&'a mut self) -> Option<PointerMutGuard<'a, T>> {
+    pub fn acquire(&mut self) -> Option<PointerMutGuard<'_, T>> {
         if T::acquire(self.ptr as usize) {
             let guard = PointerMutGuard { inner: self };
             if !guard.validate() {

--- a/rmm/src/macro.rs
+++ b/rmm/src/macro.rs
@@ -16,34 +16,34 @@ macro_rules! define_interface {
 macro_rules! print {
     ($($arg:tt)*) => {
         let buffer = alloc::format!($($arg)*);
-        let _ = $crate::io::stdout().write_all(buffer.as_bytes());
+        let _ = crate::io::stdout().write_all(buffer.as_bytes());
     };
 }
 
 #[macro_export]
 macro_rules! println {
-    () => {$crate::print!("\n")};
-    ($fmt:expr) => {$crate::print!(concat!($fmt, "\n"))};
-    ($fmt:expr, $($arg:tt)*) => {$crate::print!(concat!($fmt, "\n"), $($arg)*)};
+    () => {crate::print!("\n")};
+    ($fmt:expr) => {crate::print!(concat!($fmt, "\n"))};
+    ($fmt:expr, $($arg:tt)*) => {crate::print!(concat!($fmt, "\n"), $($arg)*)};
 }
 
 #[macro_export]
 macro_rules! eprint {
     ($fmt:expr) => {
         let buffer = concat!("\x1b[0;31m", $fmt, "\x1b[0m");
-        let _ = $crate::io::stdout().write_all(buffer.as_bytes());
+        let _ = crate::io::stdout().write_all(buffer.as_bytes());
     };
     ($fmt:expr, $($arg:tt)*) => {{
         let buffer = alloc::format!(concat!("\x1b[0;31m", $fmt, "\x1b[0m"), $($arg)*);
-        let _ = $crate::io::stdout().write_all(buffer.as_bytes());
+        let _ = crate::io::stdout().write_all(buffer.as_bytes());
     }};
 }
 
 #[macro_export]
 macro_rules! eprintln {
-    () => {$crate::eprint!("\n")};
-    ($fmt:expr) => {$crate::eprint!(concat!($fmt, "\n"))};
-    ($fmt:expr, $($arg:tt)*) => {$crate::eprint!(concat!($fmt, "\n"), $($arg)*)};
+    () => {crate::eprint!("\n")};
+    ($fmt:expr) => {crate::eprint!(concat!($fmt, "\n"))};
+    ($fmt:expr, $($arg:tt)*) => {crate::eprint!(concat!($fmt, "\n"), $($arg)*)};
 }
 
 #[macro_export]
@@ -58,8 +58,7 @@ macro_rules! const_assert {
 macro_rules! const_assert_eq {
     ($left:expr, $right:expr) => {
         const _: () = {
-            $crate::const_assert!($left == $right);
-            ()
+            crate::const_assert!($left == $right);
         };
     };
 }
@@ -67,7 +66,7 @@ macro_rules! const_assert_eq {
 #[macro_export]
 macro_rules! const_assert_size {
     ($struct:ty, $size:expr) => {
-        $crate::const_assert_eq!(core::mem::size_of::<$struct>(), ($size));
+        crate::const_assert_eq!(core::mem::size_of::<$struct>(), ($size));
     };
 }
 

--- a/rmm/src/measurement/ctx.rs
+++ b/rmm/src/measurement/ctx.rs
@@ -30,7 +30,7 @@ impl<'a> HashContext<'a> {
 
     pub fn extend_measurement(&self, buffer: &[u8], index: usize) -> Result<(), rsi::error::Error> {
         crate::rsi::measurement::extend(self.rd.id(), index, |current| {
-            let old_value = current.clone();
+            let old_value = *current;
 
             self.hasher.hash_fields_into(current, |h| {
                 h.hash(&old_value.as_ref()[0..self.hasher.output_size()]);
@@ -54,7 +54,7 @@ impl<'a> HashContext<'a> {
         }
 
         crate::rsi::measurement::extend(self.rd.id(), MEASUREMENTS_SLOT_RIM, |current| {
-            let oldrim = current.clone();
+            let oldrim = *current;
 
             self.hasher.hash_fields_into(current, |h| {
                 h.hash_u8(MEASURE_DESC_TYPE_DATA); // desc type
@@ -75,7 +75,7 @@ impl<'a> HashContext<'a> {
             .hash_object_into(params, &mut params_measurement)?;
 
         crate::rsi::measurement::extend(self.rd.id(), MEASUREMENTS_SLOT_RIM, |current| {
-            let oldrim = current.clone();
+            let oldrim = *current;
 
             self.hasher.hash_fields_into(current, |h| {
                 h.hash_u8(MEASURE_DESC_TYPE_REC); // desc type
@@ -90,7 +90,7 @@ impl<'a> HashContext<'a> {
 
     pub fn measure_ripas_granule(&self, ipa: usize, level: u8) -> Result<(), rsi::error::Error> {
         crate::rsi::measurement::extend(self.rd.id(), MEASUREMENTS_SLOT_RIM, |current| {
-            let oldrim = current.clone();
+            let oldrim = *current;
 
             self.hasher.hash_fields_into(current, |h| {
                 h.hash_u8(MEASURE_DESC_TYPE_RIPAS); // desc type

--- a/rmm/src/measurement/hash.rs
+++ b/rmm/src/measurement/hash.rs
@@ -91,7 +91,7 @@ impl Hasher {
         obj: &dyn Hashable,
         mut out: impl AsMut<[u8]>,
     ) -> Result<(), MeasurementError> {
-        obj.hash(&self, out.as_mut())
+        obj.hash(self, out.as_mut())
     }
 
     pub fn output_size(&self) -> usize {

--- a/rmm/src/mm/translation.rs
+++ b/rmm/src/mm/translation.rs
@@ -80,7 +80,7 @@ impl<'a> Inner<'a> {
     }
 
     fn fill(&mut self) {
-        if self.dirty == true {
+        if self.dirty {
             return;
         }
 
@@ -94,7 +94,7 @@ impl<'a> Inner<'a> {
             let rw_start = &__RW_START__ as *const u64 as u64;
             let ro_size = rw_start - base_address;
             let rw_size = &__RW_END__ as *const u64 as u64 - rw_start;
-            let uart_phys = 0x1c0c0000 as u64;
+            let uart_phys: u64 = 0x1c0c_0000;
             self.set_pages(
                 VirtAddr::from(base_address),
                 PhysAddr::from(base_address),

--- a/rmm/src/realm/context.rs
+++ b/rmm/src/realm/context.rs
@@ -95,16 +95,13 @@ pub fn get_reg(id: usize, vcpu: usize, register: usize) -> Result<usize, Error> 
 
 impl crate::realm::vcpu::Context for Context {
     fn new() -> Self {
-        let mut context: Self = Default::default();
-
         // Set appropriate sys registers
-        context.spsr =
-            SPSR_EL2::D | SPSR_EL2::A | SPSR_EL2::I | SPSR_EL2::F | (SPSR_EL2::M & 0b0101);
-
         // TODO: enable floating point
         // CPTR_EL2, CPACR_EL1, update vectors.s, etc..
-
-        context
+        Self {
+            spsr: SPSR_EL2::D | SPSR_EL2::A | SPSR_EL2::I | SPSR_EL2::F | (SPSR_EL2::M & 0b0101),
+            ..Default::default()
+        }
     }
 
     unsafe fn into_current(vcpu: &mut VCPU<Self>) {

--- a/rmm/src/realm/mm/stage2_translation.rs
+++ b/rmm/src/realm/mm/stage2_translation.rs
@@ -188,9 +188,9 @@ impl<'a> IPATranslation for Stage2Translation<'a> {
             Ok(None)
         });
         if let Ok(x) = res {
-            return Some((pte, x.1));
+            Some((pte, x.1))
         } else {
-            return None;
+            None
         }
     }
 
@@ -207,9 +207,9 @@ impl<'a> IPATranslation for Stage2Translation<'a> {
             Ok(None)
         });
         if let Ok(_x) = res {
-            return Ok(());
+            Ok(())
         } else {
-            return Err(Error::RmiErrorInput);
+            Err(Error::RmiErrorInput)
         }
     }
 

--- a/rmm/src/realm/mm/stage2_tte.rs
+++ b/rmm/src/realm/mm/stage2_tte.rs
@@ -130,7 +130,7 @@ impl S2TTE {
             return false;
         }
 
-        return true;
+        true
     }
 
     pub fn is_unassigned(&self) -> bool {

--- a/rmm/src/realm/mod.rs
+++ b/rmm/src/realm/mod.rs
@@ -35,15 +35,14 @@ impl<T: Context + Default> Realm<T> {
     ) -> Arc<Mutex<Self>> {
         Arc::new({
             let vcpus = Vec::new();
-            let realm = Mutex::new(Self {
+            Mutex::new(Self {
                 id,
                 vmid,
                 state: State::New,
-                vcpus: vcpus,
-                page_table: page_table,
+                vcpus,
+                page_table,
                 measurements: [Measurement::empty(); MEASUREMENTS_SLOT_NR],
-            });
-            realm
+            })
         })
     }
 }

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -12,5 +12,5 @@ type RealmMap = BTreeMap<usize, RealmMutex>;
 pub static RMS: Spinlock<(usize, RealmMap)> = Spinlock::new((0, BTreeMap::new()));
 
 pub fn get_realm(id: usize) -> Option<RealmMutex> {
-    RMS.lock().1.get(&id).map(|realm| Arc::clone(realm))
+    RMS.lock().1.get(&id).map(Arc::clone)
 }

--- a/rmm/src/realm/timer.rs
+++ b/rmm/src/realm/timer.rs
@@ -32,13 +32,13 @@ pub fn restore_state(vcpu: &VCPU<Context>) {
 pub fn save_state(vcpu: &mut VCPU<Context>) {
     let timer = &mut vcpu.context.timer;
 
-    *&mut timer.cntvoff_el2 = unsafe { CNTVOFF_EL2.get() };
-    *&mut timer.cntv_cval_el0 = unsafe { CNTV_CVAL_EL0.get() };
-    *&mut timer.cntv_ctl_el0 = unsafe { CNTV_CTL_EL0.get() };
-    *&mut timer.cntpoff_el2 = unsafe { S3_4_C14_C0_6.get() }; // CNTPOFF_EL2
-    *&mut timer.cntp_cval_el0 = unsafe { CNTP_CVAL_EL0.get() };
-    *&mut timer.cntp_ctl_el0 = unsafe { CNTP_CTL_EL0.get() };
-    *&mut timer.cnthctl_el2 = unsafe { S3_4_C14_C1_0.get() };
+    timer.cntvoff_el2 = unsafe { CNTVOFF_EL2.get() };
+    timer.cntv_cval_el0 = unsafe { CNTV_CVAL_EL0.get() };
+    timer.cntv_ctl_el0 = unsafe { CNTV_CTL_EL0.get() };
+    timer.cntpoff_el2 = unsafe { S3_4_C14_C0_6.get() }; // CNTPOFF_EL2
+    timer.cntp_cval_el0 = unsafe { CNTP_CVAL_EL0.get() };
+    timer.cntp_ctl_el0 = unsafe { CNTP_CTL_EL0.get() };
+    timer.cnthctl_el2 = unsafe { S3_4_C14_C1_0.get() };
 }
 
 pub fn send_state_to_host(id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error> {

--- a/rmm/src/realm/vcpu.rs
+++ b/rmm/src/realm/vcpu.rs
@@ -40,7 +40,7 @@ impl<T: Context + Default> VCPU<T> {
     pub fn new(realm: Arc<Mutex<Realm<T>>>) -> Arc<Mutex<Self>> {
         Arc::<Mutex<Self>>::new_cyclic(|me| {
             Mutex::new(Self {
-                realm: realm,
+                realm,
                 me: me.clone(),
                 state: State::Ready,
                 context: T::new(),

--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -70,7 +70,7 @@ pub fn ipa_bits(feat_reg0: usize) -> usize {
 pub fn validate(feat_reg0: usize) -> bool {
     const MIN_IPA_SIZE: usize = 32;
     let s2sz = extract(feat_reg0, S2SZ_SHIFT, S2SZ_WIDTH);
-    if s2sz < MIN_IPA_SIZE || s2sz > S2SZ_VALUE {
+    if !(MIN_IPA_SIZE..=S2SZ_VALUE).contains(&s2sz) {
         return false;
     }
 

--- a/rmm/src/rmi/mod.rs
+++ b/rmm/src/rmi/mod.rs
@@ -86,7 +86,7 @@ pub struct MapProt(usize);
 
 impl From<usize> for MapProt {
     fn from(prot: usize) -> Self {
-        Self(prot as usize)
+        Self(prot)
     }
 }
 

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -57,7 +57,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         if params.rtt_base as usize == rd {
             return Err(Error::RmiErrorInput);
         }
-        if !(params.rtt_base as usize % GRANULE_SIZE == 0) {
+        if params.rtt_base as usize % GRANULE_SIZE != 0 {
             return Err(Error::RmiErrorInput);
         }
         let _ = get_granule_if!(params.rtt_base as usize, GranuleState::Delegated)?;
@@ -119,7 +119,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 fn create_realm(vmid: u16, rtt_base: usize) -> Result<usize, Error> {
     let mut rms = RMS.lock();
 
-    for (_, realm) in &rms.1 {
+    for realm in rms.1.values() {
         if vmid == realm.lock().vmid {
             return Err(Error::RmiErrorInput);
         }

--- a/rmm/src/rmi/rec/exit.rs
+++ b/rmm/src/rmi/rec/exit.rs
@@ -95,7 +95,7 @@ fn get_write_val(realm_id: usize, vcpu_id: usize, esr_el2: u64) -> Result<u64, E
 
 fn handle_data_abort(
     realm_exit_res: [usize; 4],
-    rec: &mut Rec<'_>,
+    rec: &Rec<'_>,
     run: &mut Run,
 ) -> Result<usize, Error> {
     let realm_id = rec.realmid()?;

--- a/rmm/src/rmi/rec/mod.rs
+++ b/rmm/src/rmi/rec/mod.rs
@@ -229,12 +229,14 @@ pub fn run(id: usize, vcpu: usize, incr_pc: usize) -> Result<[usize; 4], Error> 
             .elr
     );
 
-    get_realm(id)
+    if let Some(vcpu) = get_realm(id)
         .ok_or(Error::RmiErrorOthers(NotExistRealm))?
         .lock()
         .vcpus
         .get(vcpu)
-        .map(|vcpu| VCPU::into_current(&mut *vcpu.lock()));
+    {
+        VCPU::into_current(&mut *vcpu.lock())
+    }
 
     trace!("Switched to VCPU {} on Realm {}", vcpu, id);
     let ret = enter();

--- a/rmm/src/rmi/rec/params.rs
+++ b/rmm/src/rmi/rec/params.rs
@@ -89,7 +89,7 @@ impl HostAccessor for Params {
             return false;
         }
 
-        return true;
+        true
     }
 }
 

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -87,7 +87,7 @@ impl Run {
     }
 
     pub unsafe fn set_cntv_ctl(&mut self, val: u64) {
-        *(&mut (*(*self.exit.inner).cnt.inner).v_ctl) = val;
+        (*(*self.exit.inner).cnt.inner).v_ctl = val;
     }
 
     pub unsafe fn set_cntv_cval(&mut self, val: u64) {
@@ -370,6 +370,6 @@ impl HostAccessor for Run {
                 }
             }
         }
-        return true;
+        true
     }
 }

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -47,7 +47,7 @@ fn is_valid_rtt_cmd(ipa: usize, level: usize) -> bool {
     if ipa & mask as usize != ipa {
         return false;
     }
-    return true;
+    true
 }
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
@@ -96,7 +96,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         }
         crate::rtt::init_ripas(rd.id(), ipa, level)?;
 
-        HashContext::new(&rd)?.measure_ripas_granule(ipa, level as u8)?;
+        HashContext::new(rd)?.measure_ripas_granule(ipa, level as u8)?;
 
         Ok(())
     });
@@ -197,7 +197,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         // read src page
         let src_page = copy_from_host_or_ret!(DataPage, src_pa);
 
-        HashContext::new(&rd)?.measure_data_granule(&src_page, ipa, flags)?;
+        HashContext::new(rd)?.measure_data_granule(&src_page, ipa, flags)?;
 
         // 3. copy src to _data
         *target_page = src_page;

--- a/rmm/src/rsi/attestation/mod.rs
+++ b/rmm/src/rsi/attestation/mod.rs
@@ -1,6 +1,6 @@
 pub mod claims;
 
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use ciborium::{ser, Value};
 use coset::{CoseSign1Builder, HeaderBuilder, TaggedCborSerializable};
 use ecdsa::signature::Signer;
@@ -69,12 +69,10 @@ impl Attestation {
             Value::Bytes(self.platform_token.to_vec()),
         );
 
-        let mut token_map: Vec<(Value, Value)> = Vec::new();
-        token_map.push(platform_token_entry);
-        token_map.push(realm_token_entry);
+        let token_map: Vec<(Value, Value)> = vec![platform_token_entry, realm_token_entry];
 
         ser::into_writer(
-            &Value::Tag(CCA_TOKEN_COLLECTION.into(), Box::new(Value::Map(token_map))),
+            &Value::Tag(CCA_TOKEN_COLLECTION, Box::new(Value::Map(token_map))),
             &mut cca_token,
         )
         .expect("Failed to serialize CCA token");
@@ -109,15 +107,15 @@ impl Attestation {
             String::from("sha-256"),
         );
 
-        let mut claims_map: Vec<(Value, Value)> = Vec::new();
-
-        claims_map.push(claims.challenge.into());
-        claims_map.push(claims.personalization_value.into());
-        claims_map.push(claims.rim.into());
-        claims_map.push(claims.rems.into());
-        claims_map.push(claims.measurement_hash_algo.into());
-        claims_map.push(claims.rak_pub.into());
-        claims_map.push(claims.rak_pub_hash_algo.into());
+        let claims_map: Vec<(Value, Value)> = vec![
+            claims.challenge.into(),
+            claims.personalization_value.into(),
+            claims.rim.into(),
+            claims.rems.into(),
+            claims.measurement_hash_algo.into(),
+            claims.rak_pub.into(),
+            claims.rak_pub_hash_algo.into(),
+        ];
 
         let mut realm_token = Vec::new();
         ser::into_writer(&Value::Map(claims_map), &mut realm_token)

--- a/rmm/src/rsi/hostcall.rs
+++ b/rmm/src/rsi/hostcall.rs
@@ -27,7 +27,7 @@ impl HostCall {
     // Safety: union type should be initialized
     // Check UB
     pub fn imm(&self) -> u16 {
-        unsafe { self.inner.val.imm as u16 }
+        unsafe { self.inner.val.imm }
     }
 }
 

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -42,7 +42,9 @@ pub const ERROR_INPUT: usize = 1;
 pub const ERROR_STATE: usize = 2;
 pub const INCOMPLETE: usize = 3;
 
-pub const VERSION: usize = (1 << 16) | 0;
+const ABI_VERSION_MAJOR: usize = 1;
+const ABI_VERSION_MINOR: usize = 0;
+pub const VERSION: usize = (ABI_VERSION_MAJOR << 16) | ABI_VERSION_MINOR;
 
 extern crate alloc;
 
@@ -237,7 +239,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
         let rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
         let rd = rd.content::<Rd>();
-        HashContext::new(&rd)?.extend_measurement(&buffer[0..size], index)?;
+        HashContext::new(rd)?.extend_measurement(&buffer[0..size], index)?;
 
         set_reg(realmid, vcpuid, 0, SUCCESS)?;
         ret[0] = rmi::SUCCESS_REC_ENTER;

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# TODO: Enable missing_safety_doc
+cargo clippy --lib -p islet_rmm -- \
+	-A clippy::comparison_chain \
+	-A clippy::crate_in_macro_def \
+	-A clippy::empty_loop \
+	-A clippy::explicit_auto_deref \
+	-A clippy::from_over_into \
+	-A clippy::len_without_is_empty \
+	-A clippy::manual_range_contains \
+	-A clippy::match_like_matches_macro \
+	-A clippy::missing_safety_doc \
+	-A clippy::new_without_default \
+	-A clippy::type_complexity

--- a/scripts/deps/rust.sh
+++ b/scripts/deps/rust.sh
@@ -16,6 +16,7 @@ rustup component add rust-src rustfmt
 
 # sdk
 rustup target add aarch64-unknown-linux-gnu
+rustup component add clippy
 
 cargo install cargo-bloat cbindgen mdbook
 


### PR DESCRIPTION
This PR applies clippy lints to rmm related code and CI.

## How to run
You may just run the script.
```sh
./scripts/clippy.sh
```

or execute the command at root.

```sh
cargo clippy --lib -p islet_rmm -- \
	-A clippy::comparison_chain \
	-A clippy::crate_in_macro_def \
	-A clippy::empty_loop \
	-A clippy::explicit_auto_deref \
	-A clippy::from_over_into \
	-A clippy::len_without_is_empty \
	-A clippy::manual_range_contains \
	-A clippy::match_like_matches_macro \
	-A clippy::missing_safety_doc \
	-A clippy::new_without_default \
	-A clippy::type_complexity
```