### PR TITLE
vmsa: Add MemAlloc trait for PageTable

### DIFF
--- a/lib/vmsa/src/lib.rs
+++ b/lib/vmsa/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(incomplete_features)]
 #![deny(warnings)]
 #![feature(specialization)]
+#![feature(generic_const_exprs)]
 #![warn(rust_2018_idioms)]
 
 pub mod address;

--- a/lib/vmsa/src/page_table.rs
+++ b/lib/vmsa/src/page_table.rs
@@ -275,6 +275,7 @@ impl<A: Address, L: HasSubtable, E: Entry, const N: usize> PageTableMethods<A, L
     for PageTable<A, L, E, N>
 where
     L::NextLevel: Level,
+    [E; L::NextLevel::NUM_ENTRIES]: Sized,
 {
     fn entry<S: PageSize, F: FnMut(&mut E) -> Result<Option<EntryGuard<'_, E::Inner>>, Error>>(
         &mut self,
@@ -332,8 +333,6 @@ where
 
         if L::THIS_LEVEL < S::MAP_TABLE_LEVEL {
             self.entries[index].set_with_page_table_flags_via_alloc(index, || {
-                assert_eq!(N, L::NextLevel::NUM_ENTRIES);
-
                 let subtable = unsafe {
                     alloc::alloc::alloc_zeroed(
                         alloc::alloc::Layout::from_size_align(
@@ -342,12 +341,15 @@ where
                         )
                         .unwrap(),
                     )
-                } as *mut PageTable<A, L::NextLevel, E, N>;
+                }
+                    as *mut PageTable<A, L::NextLevel, E, { L::NextLevel::NUM_ENTRIES }>;
 
                 if subtable as usize != 0 {
-                    let subtable_ptr = subtable as *mut PageTable<A, L::NextLevel, E, N>;
+                    let subtable_ptr = subtable
+                        as *mut PageTable<A, L::NextLevel, E, { L::NextLevel::NUM_ENTRIES }>;
                     unsafe {
-                        let arr: [E; N] = core::array::from_fn(|_| E::new());
+                        let arr: [E; L::NextLevel::NUM_ENTRIES] =
+                            core::array::from_fn(|_| E::new());
                         (*subtable_ptr).entries = arr;
                     }
                 }

--- a/rmm/src/realm/mm/stage2_translation.rs
+++ b/rmm/src/realm/mm/stage2_translation.rs
@@ -12,10 +12,11 @@ use crate::realm::mm::address::GuestPhysAddr;
 use crate::realm::mm::translation_granule_4k::RawPTE;
 use crate::realm::mm::IPATranslation;
 use crate::rmi::error::Error;
+use alloc::alloc::Layout;
 use vmsa::address::PhysAddr;
 use vmsa::page::{Page, PageIter, PageSize};
 use vmsa::page_table::Entry;
-use vmsa::page_table::{Level, PageTable, PageTableMethods};
+use vmsa::page_table::{Level, MemAlloc, PageTable, PageTableMethods};
 
 use armv9a::{bits_in_reg, define_bitfield, define_bits, define_mask};
 
@@ -111,6 +112,30 @@ impl<'a> Stage2Translation<'a> {
                 );
             }
         }
+    }
+}
+
+impl<'a> MemAlloc for Stage2Translation<'a> {
+    unsafe fn alloc(layout: Layout) -> *mut u8 {
+        error!("alloc for Stage2Translation is not allowed. {:?}", layout);
+        // Safety: the caller must do proper error handling with this null pointer.
+        core::ptr::null_mut()
+    }
+
+    unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
+        error!(
+            "alloc_zeroed for Stage2Translation is not allowed. {:?}",
+            layout
+        );
+        // Safety: the caller must do proper error handling with this null pointer.
+        core::ptr::null_mut()
+    }
+
+    unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
+        error!(
+            "dealloc for Stage2Translation is not allowed. {:?}, {:?}",
+            ptr, layout
+        );
     }
 }
 


### PR DESCRIPTION
This PR is based by the following requests:
1. Subtable's entry size don't need to be fixed by the first page table entry size 'N'
2. A new trait for memory alloc/dealloc is needed for PageTable structure for allowing to have different memory management methods per PageTable. (especially for stage2 page table)