### PR TITLE
doc: Apply new org url

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ safety and concurrency safety.
 Moving forward, we also plan to incorporate formal 
 verification techniques to further enhance the security of our design and implementation.
 
-For more information, please visit our [developer site](https://samsung.github.io/islet/).
+For more information, please visit our [developer site](https://islet-project.github.io/islet/).
 
 ## A demo video (Confidential ML)
 

--- a/doc/components/attestation.md
+++ b/doc/components/attestation.md
@@ -12,7 +12,7 @@ An attestation report (shortly, *report*) is an *evidence* produced by *attester
 - *CCA Platform token*: it is used to assure that *attester* is running on a secure CCA platform. It covers the measurements of CCA platform components (e.g., RMM and EL3M) and whether it is in debug state.
 - *Realm token*: this token is used to hold the measurement of Realm, which is equivalent to a virtual machine that may contain kernel and root file system.
 
-You can quickly test and see what this report looks like through [our CLI tool](https://samsung.github.io/islet/components/cli.html).
+You can quickly test and see what this report looks like through [our CLI tool](https://islet-project.github.io/islet/components/cli.html).
 
 ## Appraisal policy
 

--- a/doc/components/index.md
+++ b/doc/components/index.md
@@ -1,7 +1,7 @@
 # Contents
-- [2.1. CCA platform architecture](https://samsung.github.io/islet/components/cca_design.html)
-- [2.2. Realm Management Monitor](https://samsung.github.io/islet/components/rmm.html)
-- [2.3. Command Line Interface](https://samsung.thub.io/islet/components/cli.html)
-- [2.4. Software Development Kit](https://samsung.github.io/islet/components/sdk.html)
-- [2.5. Attestation](https://samsung.github.io/islet/components/attestation.html)
-- [2.6. Certifier](https://samsung.github.io/islet/ents/certifier.html)
+- [2.1. CCA platform architecture](https://islet-project.github.io/islet/components/cca_design.html)
+- [2.2. Realm Management Monitor](https://islet-project.github.io/islet/components/rmm.html)
+- [2.3. Command Line Interface](https://islet-project.github.io/islet/components/cli.html)
+- [2.4. Software Development Kit](https://islet-project.github.io/islet/components/sdk.html)
+- [2.5. Attestation](https://islet-project.github.io/islet/components/attestation.html)
+- [2.6. Certifier](https://islet-project.github.io/islet/components/certifier.html)

--- a/doc/crates/index.md
+++ b/doc/crates/index.md
@@ -1,3 +1,3 @@
 # Contents
-- [5.1. Realm Management Monitor](https://samsung.github.io/islet/plat-doc/monitor/index.html)
-- [5.2. Confidential Application SDK](https://samsung.github.io/islet/app-doc/islet_sdk/index.html)
+- [5.1. Realm Management Monitor](https://islet-project.github.io/islet/plat-doc/monitor/index.html)
+- [5.2. Confidential Application SDK](https://islet-project.github.io/islet/app-doc/islet_sdk/index.html)

--- a/doc/getting-started/app-dev.md
+++ b/doc/getting-started/app-dev.md
@@ -8,7 +8,7 @@ You can run Confidential Applications not only on Arm FVP(arm64)
 but also on Host PC(x86_64, simulated version) with `Islet SDK`.
 
 For more information about `Islet SDK`,
-please refer [this document](https://samsung.github.io/islet/components/sdk.html).
+please refer [this document](https://islet-project.github.io/islet/components/sdk.html).
 
 ## Setting Rust environment
 The first step is to prepare Rust environment.

--- a/doc/getting-started/index.md
+++ b/doc/getting-started/index.md
@@ -1,4 +1,4 @@
 # Contents
-- [1.1. About CCA](https://samsung.github.io/islet/getting-started/cca.html)
-- [1.2. Application Developer](https://samsung.github.io/islet/getting-started/app-dev.html)
-- [1.3. Platform Developer](https://samsung.github.io/islet/getting-started/plat-dev.html)
+- [1.1. About CCA](https://islet-project.github.io/islet/getting-started/cca.html)
+- [1.2. Application Developer](https://islet-project.github.io/islet/getting-started/app-dev.html)
+- [1.3. Platform Developer](https://islet-project.github.io/islet/getting-started/plat-dev.html)

--- a/doc/platform-development/index.md
+++ b/doc/platform-development/index.md
@@ -1,2 +1,2 @@
 # Contents
-- [3.1. Secure interactions with Host](https://samsung.github.io/islet/platform-development/secure-interaction.html)
+- [3.1. Secure interactions with Host](https://islet-project.github.io/islet/platform-development/secure-interaction.html)

--- a/doc/usecases/index.md
+++ b/doc/usecases/index.md
@@ -1,2 +1,2 @@
 # Contents
-- [4.1. Confidential Machine Learning](https://samsung.github.io/islet/usecases/confidential_ml.html)
+- [4.1. Confidential Machine Learning](https://islet-project.github.io/islet/usecases/confidential_ml.html)


### PR DESCRIPTION
Note : There was typo on [1](https://github.com/islet-project/islet/compare/doc-new-org?expand=1#diff-622c19b11ccbda258b9458bbeb8aeb35fe20311bfd6c32ffe8a24bda625d52cdL4) and [2](https://github.com/islet-project/islet/compare/doc-new-org?expand=1#diff-622c19b11ccbda258b9458bbeb8aeb35fe20311bfd6c32ffe8a24bda625d52cdL7). Please let me know if this is intended