### PR TITLE
tools: Add unsafe analyzer `cargo gegier`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,3 +181,19 @@ jobs:
     - name: Run cli build (x86_64, aarch64)
       working-directory: cli
       run: make
+
+  rust-unsafe-analysis:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: ./scripts/init-unsafe-analysis.sh
+
+    - name: Run unsafe analyzer
+      run: ./scripts/analyze-unsafe.sh
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: tools
+        path: out/unsafe-analysis.log

--- a/.gitmodules
+++ b/.gitmodules
@@ -60,3 +60,6 @@
 [submodule "third-party/certifier"]
 	path = third-party/certifier
 	url = https://github.com/vmware-research/certifier-framework-for-confidential-computing
+[submodule "third-party/cargo-geiger"]
+	path = third-party/cargo-geiger
+	url = https://github.com/bitboom/cargo-geiger

--- a/scripts/analyze-unsafe.sh
+++ b/scripts/analyze-unsafe.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+TOOL=$ROOT/third-party/cargo-geiger
+OUT=$ROOT/out
+
+mkdir -p $OUT
+
+cd $ROOT/plat/fvp
+cargo geiger --output-format Ratio | tee $OUT/unsafe-analysis.log

--- a/scripts/init-unsafe-analysis.sh
+++ b/scripts/init-unsafe-analysis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+HERE=$ROOT/scripts
+TOOL=$ROOT/third-party/cargo-geiger
+
+$HERE/deps/rust.sh
+
+git submodule update --init $TOOL
+cargo +stable install cargo-geiger --force --locked \
+	--path $TOOL/cargo-geiger \
+	--target x86_64-unknown-linux-gnu


### PR DESCRIPTION
This PR introduces `cargo gegier` to analysis `unsafe ratio`.
You can check this on [CI](https://github.com/islet-project/islet/actions/runs/7605666158/job/20710259988).

```sh
Functions  Expressions  Impls  Traits  Methods  Dependency
1/6=16.67%     8/42=19.05%        0/0=100.00%        0/0=100.00%     0/0=100.00%  !  fvp 0.0.1
2/2=100.00%    16/18=88.89%        1/1=100.00%        0/0=100.00%     1/1=100.00%  !  ├── armv9a 0.0.1
20/20=100.00%    75/75=100.00%      15/15=100.00%       0/0=100.00%    15/15=100.00%  ?  ├── bitflags 1.3.2
116/126=92.06%  3776/4746=79.56%    134/136=98.53%       7/7=100.00%   269/297=90.57%  !  ├── islet_rmm 0.0.1
...
1687/1740=96.95% 122331/126205=96.93%  5926/6029=98.29%    353/375=94.13%  8456/8562=98.76%
```