### PR TITLE
doc: Add `Remote Attestation` to dev-site

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -20,6 +20,7 @@
 - [Use Cases](./usecases/index.md)
   - [Confidential Machine Learning](./usecases/confidential_ml.md)
   - [Cross Platform E2EE](./usecases/cross-platform-e2ee.md)
+  - [Remote Attestation](./usecases/remote-attestation.md)
 - [Rust Crates](./crates/index.md)
   - [Realm Management Monitor](./plat-doc/islet_rmm/index.html)
   - [Confidential Application SDK](./app-doc/islet_sdk/index.html)

--- a/doc/usecases/cross-platform-e2ee.md
+++ b/doc/usecases/cross-platform-e2ee.md
@@ -1,0 +1,1 @@
+../../examples/cross-platform-e2ee/README.md

--- a/doc/usecases/index.md
+++ b/doc/usecases/index.md
@@ -1,3 +1,4 @@
 # Contents
 - [4.1. Confidential Machine Learning](https://islet-project.github.io/islet/usecases/confidential_ml.html)
 - [4.2. Cross Platform E2EE](https://islet-project.github.io/islet/usecases/cross-platform-e2ee.html)
+- [4.3. Remote Attestation](https://islet-project.github.io/islet/usecases/remote-attestation.html)

--- a/examples/cross-platform-e2ee/README.md
+++ b/examples/cross-platform-e2ee/README.md
@@ -15,7 +15,7 @@ to demonstrate E2EE between x64 and arm64 platforms.
 ## Components
 This example consists of three main components:
 
-![xplat-e2ee-components](res/xplat-e2ee-components.png)
+![xplat-e2ee-components](https://github.com/islet-project/islet/blob/main/examples/cross-platform-e2ee/res/xplat-e2ee-components.png?raw=true)
 
 - Certifier Service: An x64 service responsible for performing attestation and checking against a pre-written policy
 - E2EE Server App: An x64 application that requests attestation to the service and attempts to establish a secure channel with the client

--- a/scripts/make_doc.sh
+++ b/scripts/make_doc.sh
@@ -14,6 +14,7 @@ ln -sf ../../rmm/README.md rmm.md
 cd ${ROOT}/doc/usecases
 ln -sf ../../examples/confidential-ml/README.md confidential-ml.md
 ln -sf ../../examples/cross-platform-e2ee/README.md cross-platform-e2ee.md
+ln -sf ../../examples/veraison/README.md remote-attestation.md
 
 # RMM crate
 rm -rf ${ROOT}/doc/plat-doc


### PR DESCRIPTION
This PR adds `Remote Attestation` to our dev-site.
Please refer [this](https://islet-project.github.io/islet/usecases/remote-attestation.html).
(_Our dev-site is latest version include https://github.com/islet-project/islet/pull/266_).