### PR TITLE
 Add neon in target-feature to resolve a dependency issue

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,3 +1,8 @@
 [build]
 target = "aarch64-unknown-none-softfloat"
 target-dir = "out"
+
+[target.aarch64-unknown-none-softfloat]
+rustflags = [
+  "-C", "target-feature=+neon",
+]

--- a/plat/fvp/.cargo/config
+++ b/plat/fvp/.cargo/config
@@ -3,5 +3,6 @@ target = "aarch64-unknown-none-softfloat"
 
 [target.aarch64-unknown-none-softfloat]
 rustflags = [
-  "-C", "link-args=-Tplat/fvp/memory.x",
+  "-C", "link-args=-Tplat/fvp/memory.x", 
+  "-C", "target-feature=+neon",
 ]


### PR DESCRIPTION
This PR would resolve the below issue in CI, which was caused by `half` crate's version update.

```
(in plat/fvp)
$ cargo build
...
error: register class `vreg` requires the `neon` target feature
   --> /home/changho/.cargo/registry/src/index.crates.io-6f17d22bba15001f/half-2.3.1/src/binary16/arch/aarch64.rs:171:9
    |
171 |         in(vreg) a,
    |         ^^^^^^^^^^

error: register class `vreg` requires the `neon` target feature
   --> /home/changho/.cargo/registry/src/index.crates.io-6f17d22bba15001f/half-2.3.1/src/binary16/arch/aarch64.rs:172:9
    |
172 |         in(vreg) b,
    |         ^^^^^^^^^^

error: could not compile `half` (lib) due to 32 previous errors
```