### PR TITLE
Add the shared memory mapping of rmm_el3

### DIFF
--- a/rmm/src/config.rs
+++ b/rmm/src/config.rs
@@ -12,3 +12,6 @@ pub const RMM_HEAP_SIZE: usize = 16 * 1024 * 1024;
 
 pub const VM_STACK_SIZE: usize = 1 << 15;
 pub const STACK_ALIGN: usize = 16;
+
+// TODO: Acquire this address properly.
+pub const RMM_SHARED_BUFFER_START: usize = 0xFFBFF000;

--- a/rmm/src/exception/trap.rs
+++ b/rmm/src/exception/trap.rs
@@ -194,7 +194,6 @@ pub extern "C" fn handle_lower_exception(
                 let fipa = unsafe { HPFAR_EL2.get_masked(HPFAR_EL2::FIPA) } << 8;
                 debug!("fipa: {:X}", fipa);
                 debug!("esr_el2: {:X}", esr);
-                debug!("vcpu: {:?}", vcpu);
                 RET_TO_RMM
             }
             Syndrome::SysRegInst => {

--- a/rmm/src/mm/translation.rs
+++ b/rmm/src/mm/translation.rs
@@ -1,6 +1,6 @@
 use super::page_table::entry::Entry;
 use super::page_table::{attr, L1Table};
-use crate::config::PAGE_SIZE;
+use crate::config::{PAGE_SIZE, RMM_SHARED_BUFFER_START};
 use crate::mm::page::BasePageSize;
 use crate::mm::page_table::entry::PTDesc;
 
@@ -95,6 +95,7 @@ impl<'a> Inner<'a> {
             let ro_size = rw_start - base_address;
             let rw_size = &__RW_END__ as *const u64 as u64 - rw_start;
             let uart_phys: u64 = 0x1c0c_0000;
+            let shared_start = RMM_SHARED_BUFFER_START;
             self.set_pages(
                 VirtAddr::from(base_address),
                 PhysAddr::from(base_address),
@@ -113,6 +114,12 @@ impl<'a> Inner<'a> {
                 PhysAddr::from(uart_phys),
                 1,
                 rw_flags | device_flags,
+            );
+            self.set_pages(
+                VirtAddr::from(shared_start),
+                PhysAddr::from(shared_start),
+                PAGE_SIZE,
+                rw_flags | rmm_flags,
             );
         }
         //TODO Set dirty only if pages are updated, not added

--- a/rmm/src/rmm_el3/mod.rs
+++ b/rmm/src/rmm_el3/mod.rs
@@ -10,15 +10,12 @@ mod utils;
 use crate::asm;
 use crate::config;
 use alloc::vec::Vec;
+use config::RMM_SHARED_BUFFER_START;
 use spinning_top::Spinlock;
 
 // TODO: move those consts to a more appropriate place
 const SHA256_DIGEST_SIZE: usize = 32;
 const ATTEST_KEY_CURVE_ECC_SECP384R1: usize = 0;
-
-// TODO: Acquire this address properly.
-// This is PA address, but Islet seems to be mapped 1:1 so it also works as VA.
-const RMM_SHARED_BUFFER_START: usize = 0xFFBFF000;
 
 static RMM_SHARED_BUFFER_LOCK: Spinlock<usize> = Spinlock::new(RMM_SHARED_BUFFER_START);
 static REALM_ATTEST_KEY: Spinlock<Vec<u8>> = Spinlock::new(Vec::new());


### PR DESCRIPTION
This PR adds the shared memory mapping of rmm_el3, which was not registered in RMM's page table. With the fix, the unnecessary fault related to that address would not be generated.

```
[before]
[TRACE]islet_rmm::rmm_el3 -- Setup EL3 interface
[DEBUG]islet_rmm::exception::trap::syndrome -- Data Abort without a change in Exception level
[DEBUG]islet_rmm::exception::trap -- Data Abort (higher), far:FFBFF000
[DEBUG]islet_rmm::exception::trap -- translation, level:2, esr:96000146
[TRACE]islet_rmm::rmm_el3::iface -- GET_REALM_ATTEST_KEY

[after]
[TRACE]islet_rmm::rmm_el3 -- Setup EL3 interface
[TRACE]islet_rmm::rmm_el3::iface -- GET_REALM_ATTEST_KEY
```