### PR TITLE
Use lazy_static for granule status table

### DIFF
--- a/doc/getting-started/plat-dev.md
+++ b/doc/getting-started/plat-dev.md
@@ -17,7 +17,7 @@ The first step is to prepare to build our project.
 ## Running a linux realm
 ```bash
 // Start FVP on host
-$ ./scripts/fvp-cca --normal-world=linux --realm=linux --rmm=tf-rmm
+$ ./scripts/fvp-cca --normal-world=linux --realm=linux --rmm=islet
 
 // Run a linux realm on fvp
 $ ./launch-realm.sh
@@ -45,7 +45,7 @@ To get details about its network configuration, see [network.md](https://github.
 ## Testing the realm features
 ```bash
 // Start FVP on fvp
-$ ./scripts/fvp-cca --normal-world=linux --realm=linux --rmm=tf-rmm
+$ ./scripts/fvp-cca --normal-world=linux --realm=linux --rmm=islet
 
 // Test the realm features on fvp
 $ ./test-realm.sh [attest]
@@ -62,6 +62,9 @@ $ ./scripts/fvp-cca --normal-world=tf-a-tests --rmm=tf-rmm
 
 ## Testing RMMs with [ACS](https://github.com/ARM-software/cca-rmm-acs)
 ```
+# Islet RMM
+$ ./scripts/fvp-cca --normal-world=acs --rmm=islet
+
 # TF RMM
 $ ./scripts/fvp-cca --normal-world=acs --rmm=tf-rmm
 ```

--- a/plat/fvp/src/entry.rs
+++ b/plat/fvp/src/entry.rs
@@ -2,6 +2,7 @@ use crate::allocator;
 use crate::log::LevelFilter;
 
 use armv9a::regs::*;
+use core::ptr::{addr_of, addr_of_mut};
 use islet_rmm::config::{NUM_OF_CPU, RMM_STACK_SIZE};
 use islet_rmm::io::stdout;
 use islet_rmm::logger;
@@ -76,12 +77,12 @@ unsafe fn init_mm() {
 unsafe fn setup() {
     static mut COLD_BOOT: bool = true;
 
-    if (&COLD_BOOT as *const bool).read_volatile() {
+    if (addr_of!(COLD_BOOT) as *const bool).read_volatile() {
         clear_bss();
         allocator::init();
         init_console();
         init_mm();
 
-        (&mut COLD_BOOT as *mut bool).write_volatile(false);
+        (addr_of_mut!(COLD_BOOT) as *mut bool).write_volatile(false);
     }
 }

--- a/rmm/src/granule/array/entry.rs
+++ b/rmm/src/granule/array/entry.rs
@@ -48,12 +48,9 @@ impl Granule {
         let granule_offset = entry_size - granule_size;
         let granule_addr = self as *const Granule as usize;
         let entry_addr = granule_addr - granule_offset;
-        if let Some(gst) = unsafe { &mut GRANULE_STATUS_TABLE } {
-            let table_base = gst.entries.as_ptr() as usize;
-            (entry_addr - table_base) / core::mem::size_of::<Entry>()
-        } else {
-            unreachable!();
-        }
+        let gst = &GRANULE_STATUS_TABLE;
+        let table_base = gst.entries.as_ptr() as usize;
+        (entry_addr - table_base) / core::mem::size_of::<Entry>()
     }
 
     fn index_to_addr(&self) -> usize {

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -54,6 +54,7 @@ use crate::monitor::Monitor;
 use crate::rmm_el3::setup_el3_ifc;
 
 use armv9a::{bits_in_reg, regs::*};
+use core::ptr::addr_of;
 
 pub unsafe fn start(cpu_id: usize) {
     setup_mmu_cfg();
@@ -88,7 +89,7 @@ unsafe fn setup_el2() {
             | HCR_EL2::FMO
             | HCR_EL2::VM,
     );
-    VBAR_EL2.set(&vectors as *const u64 as u64);
+    VBAR_EL2.set(addr_of!(vectors) as u64);
     SCTLR_EL2.set(SCTLR_EL2::C | SCTLR_EL2::I | SCTLR_EL2::M | SCTLR_EL2::EOS);
     CPTR_EL2.set(CPTR_EL2::TAM);
     ICC_SRE_EL2.set(ICC_SRE_EL2::ENABLE | ICC_SRE_EL2::DIB | ICC_SRE_EL2::DFB | ICC_SRE_EL2::SRE);

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -47,6 +47,7 @@ extern crate lazy_static;
 extern crate log;
 
 use crate::exception::vectors;
+#[cfg(feature = "gst_page_table")]
 use crate::granule::create_granule_status_table as setup_gst;
 use crate::mm::translation::get_page_table;
 use crate::monitor::Monitor;
@@ -57,6 +58,7 @@ use armv9a::{bits_in_reg, regs::*};
 pub unsafe fn start(cpu_id: usize) {
     setup_mmu_cfg();
     setup_el2();
+    #[cfg(feature = "gst_page_table")]
     setup_gst();
     // TODO: call once or with every start?
     if cpu_id == 0 {

--- a/scripts/tests/acs.sh
+++ b/scripts/tests/acs.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Control these variables
-EXPECTED=28
+EXPECTED=35
 TIMEOUT=4000
 
 ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
This PR refactors granule status table's initialization code to use `lazy_static` macro, so that the accesses to it would not involve unsafe operations. As a result, 3 unsafe blocks have been removed. Also, some build errors of using the latest rustc (24-03-01) have been resolved.

```
(Unsafe-analysis results from cargo-geiger)

    x = safe code found in the crate
    y = total code found in the crate
    z = percentage of safe ratio as defined by x/y

   Functions         Expressions       Module
[before]
  122/132=92.42%  3814/4802=79.43%    islet_rmm 0.0.1
[after]
  121/131=92.37%  3811/4793=79.51%    islet_rmm 0.0.1
```
