### PR TITLE
Fix a build error of e2ee setup script

### DIFF
--- a/examples/cross-platform-e2ee/setup.sh
+++ b/examples/cross-platform-e2ee/setup.sh
@@ -14,6 +14,7 @@ sudo apt install autoconf automake libtool curl make g++ unzip
 
 sudo apt install uuid-dev wget
 sudo apt install openssl libssl-dev
+sudo apt install g++-aarch64-linux-gnu
 
 # Setup utilities
 cd $HERE && git clone https://github.com/protocolbuffers/protobuf.git

--- a/examples/cross-platform-e2ee/setup.sh
+++ b/examples/cross-platform-e2ee/setup.sh
@@ -6,7 +6,7 @@ ROOT=$(git rev-parse --show-toplevel)
 HERE=$ROOT/examples/cross-platform-e2ee
 
 CERTIFIER=$ROOT/third-party/certifier
-OPENSSL=$ROOT/assets/openssl/lib
+OPENSSL=$ROOT/assets/openssl/lib-arm64
 THIRD_PARTY_ARM=$HERE/third-party-arm
 
 sudo apt install libgtest-dev libgflags-dev


### PR DESCRIPTION
This commit fixes the following error while executing e2ee example's setup.sh script.

```
(in examples/cross-platform-e2ee)
$ setup.sh
...
make[1]: Leaving directory '/islet/examples/cross-platform-e2ee/protobuf'
Cloning into 'gflags'...
remote: Enumerating objects: 2458, done.
remote: Counting objects: 100% (71/71), done.
remote: Compressing objects: 100% (42/42), done.
remote: Total 2458 (delta 32), reused 57 (delta 29), pack-reused 2387
Receiving objects: 100% (2458/2458), 1.53 MiB | 2.18 MiB/s, done.
Resolving deltas: 100% (1434/1434), done.

CMake Warning:
  No source or binary directory provided.  Both will be assumed to be the
  same as the current working directory, but note that this warning will
  become a fatal error in future CMake releases.

-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:101 (project):
  The CMAKE_CXX_COMPILER:

    aarch64-linux-gnu-g++

  is not a full path and was not found in the PATH.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.
```