### PR TITLE
rsi-el0: Remove the zero-padding in the display

### DIFF
--- a/lib/rsi-el0/src/lib.rs
+++ b/lib/rsi-el0/src/lib.rs
@@ -50,6 +50,11 @@ pub fn measurement_read(index: u32) -> nix::Result<Vec<u8>> {
     let mut measure = [kernel::RsiMeasurement::new_empty(index)];
     let fd = Fd::wrap(nix::fcntl::open(DEV, FLAGS, MODE)?);
     kernel::measurement_read(fd.get(), &mut measure)?;
+    // TODO: remove the below condition after linux-rsi module returns
+    //       the correct measurement length
+    if measure[0].data[32..] == [0; 32] {
+        measure[0].data_len = 32;
+    }
     Ok(measure[0].data[..(measure[0].data_len as usize)].to_vec())
 }
 


### PR DESCRIPTION
This commit modifies the measurement length returned from linux-rsi module. RMM returns a zero-padded measurement value and linux-rsi module currently returns the maximum measurement length. Modifying the measurment length is necessary in order not to display the zero-padding in cli. The displayed format becomes consistent with the cross-platform-e2ee example's README.

```
(in realm's shell)

[before]
$ ./islet measurement-read --index 0
[  208.236303] rsi: device rsi open
[  208.269598] rsi: ioctl: measurement_read: 0
[  208.306435] rsi: device rsi released
"be33b6c8bf03e85fec35fdd3a3b856adbc61b525e901e59d701ca33a8c71408c0000000000000000000000000000000000000000000000000000000000000000"

[after]
$ ./islet measurement-read --index 0
[  206.805345] rsi: device rsi open
[  206.838067] rsi: ioctl: measurement_read: 0
[  206.917591] rsi: device rsi released
"be33b6c8bf03e85fec35fdd3a3b856adbc61b525e901e59d701ca33a8c71408c"
```