### PR TITLE
Add auto-padding macro 

### DIFF
--- a/lib/autopadding/Cargo.toml
+++ b/lib/autopadding/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "autopadding"
+version = "0.1.0"
+
+[dependencies]
+paste = "1.0.14"
+
+[features]
+checked = []

--- a/lib/autopadding/Cargo.toml
+++ b/lib/autopadding/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "autopadding"
 version = "0.1.0"
+authors = ["Islet Contributors"]
+edition = "2021"
 
 [dependencies]
 paste = "1.0.14"

--- a/lib/autopadding/src/lib.rs
+++ b/lib/autopadding/src/lib.rs
@@ -1,0 +1,78 @@
+#![no_std]
+pub extern crate paste;
+
+#[macro_export]
+macro_rules! pad_field {
+    // entry point.
+    (@root $(#[$attr_struct:meta])* $vis:vis $name:ident { $($input:tt)* } ) => {
+        pad_field!(
+            @munch (
+                $($input)*
+            ) -> {
+                $vis struct $(#[$attr_struct])* $name
+            }
+        );
+    };
+
+    // TODO: Remove the zero-sized paddings added where no padding is required
+    (@guard ($current_offset:expr) -> {$(#[$attr:meta])* $vis:vis struct $name:ident $(($amount:expr, $vis_field:vis $id:ident: $ty:ty))*}) =>    {
+
+        $crate::paste::paste! {
+            #[repr(C)]
+            $(#[$attr])* $vis struct $name { $($vis_field $id: $ty, [<_pad $id>]: [u8;$amount]),* }
+        }
+
+    };
+
+    // Print the struct once all fields have been munched.
+    (@munch
+        (
+            $(#[$attr:meta])*
+            $offset_start:literal $vis:vis $field:ident: $ty:ty,
+            $(#[$attr_next:meta])*
+            $offset_end:literal => @END,
+        )
+        -> {$($output:tt)*}
+    ) => {
+        pad_field!(
+            @guard (
+                0
+            ) -> {
+                $($output)*
+                ($offset_end - $offset_start - core::mem::size_of::<$ty>(), $vis $field: $ty)
+            }
+        );
+    };
+
+    // Munch padding.
+    (@munch
+        (
+            $(#[$attr:meta])*
+            $offset_start:literal $vis:vis $field:ident: $ty:ty,
+            $(#[$attr_next:meta])*
+            $offset_end:literal $vis_next:vis $field_next:ident: $ty_next:ty,
+            $($after:tt)*
+        )
+        -> {$($output:tt)*}
+    ) => {
+        pad_field!(
+            @munch (
+                $(#[$attr_next])*
+                $offset_end $vis_next $field_next: $ty_next,
+                $($after)*
+            ) -> {
+                $($output)*
+                ($offset_end - $offset_start - core::mem::size_of::<$ty>(), $vis $field: $ty)
+            }
+        );
+    };
+}
+
+#[macro_export]
+macro_rules! pad_struct {
+    (
+        $(#[$attr:meta])* $vis:vis struct $name:ident {$($fields:tt)*}
+    ) => {
+        $crate::pad_field!(@root $(#[$attr])* $vis $name { $($fields)* } );
+    };
+}

--- a/rmm/Cargo.toml
+++ b/rmm/Cargo.toml
@@ -20,6 +20,7 @@ spin = "0.9.2"
 spinning_top = "0.2.4"
 sha2 = { version = "0.10.7", default-features = false }
 tinyvec = { version = "*", features = ["rustc_1_55"]}
+autopadding = { path = "../lib/autopadding" }
 
 [build-dependencies]
 cc = "1.0"

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -44,17 +44,12 @@ impl Hashable for Params {
     ) -> Result<(), crate::measurement::MeasurementError> {
         hasher.hash_fields_into(out, |alg| {
             alg.hash_u64(0); // features aren't used
-            alg.hash(self._padfeatures_0);
             alg.hash_u8(self.hash_algo);
-            alg.hash(self._padhash_algo);
             alg.hash([0u8; 64]); // rpv is not used
-            alg.hash(self._padrpv);
             alg.hash_u16(0); // vmid is not used
-            alg.hash(self._padvmid);
             alg.hash_u64(0); // rtt_base is not used
             alg.hash_u64(0); // rtt_level_start is not used
             alg.hash_u32(0); // rtt_num_start is not used
-            alg.hash(self._padrtt_num_start);
         })
     }
 }

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -5,11 +5,9 @@ use crate::measurement::Hashable;
 use crate::rmi::features;
 use crate::rmi::rtt::{RTT_PAGE_LEVEL, S2TTE_STRIDE};
 use crate::rmi::{HASH_ALGO_SHA256, HASH_ALGO_SHA512};
-use autopadding::{pad_struct, pad_field};
+use autopadding::*;
 
-const PADDING: [usize; 5] = [248, 767, 960, 6, 2020];
-
-pad_struct!(
+pad_struct_and_impl_default!(
 pub struct Params {
     0x0    pub features_0: u64,
     0x100  pub hash_algo: u8,
@@ -23,27 +21,6 @@ pub struct Params {
 );
 
 const_assert_eq!(core::mem::size_of::<Params>(), GRANULE_SIZE);
-
-impl Default for Params {
-    fn default() -> Self {
-        Self {
-            features_0: 0,
-            _padfeatures_0: [0; PADDING[0]],
-            hash_algo: 0,
-            _padhash_algo: [0; PADDING[1]],
-            rpv: [0; 64],
-            _padrpv: [0; PADDING[2]],
-            vmid: 0,
-            _padvmid: [0; PADDING[3]],
-            rtt_base: 0,
-            _padrtt_base: [0; 0],
-            rtt_level_start: 0,
-            _padrtt_level_start: [0; 0],
-            rtt_num_start: 0,
-            _padrtt_num_start: [0; PADDING[4]],
-        }
-    }
-}
 
 impl core::fmt::Debug for Params {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -15,4 +15,5 @@ cargo clippy --lib -p islet_rmm -- \
 	-A clippy::missing_safety_doc \
 	-A clippy::new_without_default \
 	-A clippy::redundant_pattern_matching \
-	-A clippy::type_complexity
+	-A clippy::type_complexity \
+	-A clippy::identity_op


### PR DESCRIPTION
# What this pr for
- Introduce auto-padding macro, with automatic impl for `Default` trait as well.

# How to use
- Wrap with `pad_struct_and_impl_default` macro on type definition.

# Note
- Supports only integer primitives and arrays of it. In case of new type field is needed(which I believe there is no use of it though), you need to add type initialization matching on `type_check_and_init` macro. For instance, to introduce `f32`, add 

~~~
    (f32) => {
        0.0
    };
~~~

- Last arm of `type_check_and_init` matches with array type.
- Any naming suggestion is welcomed