### PR TITLE
Fix structures, passed from realm, to use safe abstraction

### DIFF
--- a/rmm/Cargo.toml
+++ b/rmm/Cargo.toml
@@ -16,9 +16,10 @@ log = "0.4.17"
 vmsa = { path = "../lib/vmsa" }
 p384 = { version = "*", default-features = false, features = ["alloc", "ecdsa"] }
 ecdsa = "*"
+safe_abstraction = { path = "../lib/safe-abstraction" }
+sha2 = { version = "0.10.7", default-features = false }
 spin = "0.9.2"
 spinning_top = "0.2.4"
-sha2 = { version = "0.10.7", default-features = false }
 tinyvec = { version = "*", features = ["rustc_1_55"]}
 autopadding = { path = "../lib/autopadding" }
 

--- a/rmm/src/realm/config.rs
+++ b/rmm/src/realm/config.rs
@@ -4,13 +4,14 @@ use crate::rmi::error::Error;
 use crate::rmi::error::InternalError::*;
 use crate::rmi::rtt::RTT_PAGE_LEVEL;
 
+use safe_abstraction::raw_ptr::assume_safe;
+
 #[repr(C)]
 pub struct RealmConfig {
     ipa_width: usize,
 }
 
 impl RealmConfig {
-    #[allow(dead_code)]
     // The below `init()` fills the object allocated in the Realm kernel with the proper
     // value (ipa_width), which helps to redirect the accesses to decrypted pages.
     //
@@ -18,9 +19,10 @@ impl RealmConfig {
     // in parsing the following kernel cmdline argument:
     // `console=ttyS0 root=/dev/vda rw  console=pl011,mmio,0x1c0a0000 console=ttyAMA0 printk.devkmsg=on`.
     // So, we get back to use the same kernel argument with TF-RMM's one (uart0 & uart3).
-    pub unsafe fn init(config_addr: usize, ipa_width: usize) {
-        let config: &mut RealmConfig = &mut *(config_addr as *mut RealmConfig);
-        config.ipa_width = ipa_width;
+    pub fn init(config_addr: usize, ipa_width: usize) -> Result<(), Error> {
+        let safety_assumed = assume_safe::<RealmConfig>(config_addr).ok_or(Error::RmiErrorInput)?;
+        safety_assumed.mut_with(|config: &mut RealmConfig| config.ipa_width = ipa_width);
+        Ok(())
     }
 }
 
@@ -32,10 +34,31 @@ pub fn realm_config(id: usize, config_ipa: usize, ipa_bits: usize) -> Result<(),
         .lock()
         .ipa_to_pa(GuestPhysAddr::from(config_ipa), RTT_PAGE_LEVEL);
     if let Some(pa) = res {
-        let pa: usize = pa.into();
-        unsafe { RealmConfig::init(pa, ipa_bits) };
-        Ok(())
+        RealmConfig::init(pa.into(), ipa_bits)
     } else {
         Err(Error::RmiErrorInput)
+    }
+}
+
+impl safe_abstraction::raw_ptr::RawPtr for RealmConfig {}
+
+impl safe_abstraction::raw_ptr::SafetyChecked for RealmConfig {}
+
+impl safe_abstraction::raw_ptr::SafetyAssured for RealmConfig {
+    fn is_initialized(&self) -> bool {
+        // The initialization of this memory is guaranteed
+        // according to the RMM Specification A2.2.4 Granule Wiping.
+        // This instance belongs to a Data Granule and has been initialized.
+        true
+    }
+
+    fn verify_ownership(&self) -> bool {
+        // The instance's ownership is guaranteed while being processed by the RMM.
+        // While the Realm holds RW permissions for the instance,
+        // it cannot exercise these permissions from the moment an SMC request is made
+        // until the request is completed. Even in multi-core environments,
+        // the designated areas are protected by Stage 2 Table,
+        // ensuring that there are no adverse effects on RMM's memory safety.
+        true
     }
 }


### PR DESCRIPTION
This PR fixes structures, passed from realm, to use safe abstraction.

- Removed 3 unsafe methods & 2 unsafe code blocks

_(Followed PR: [Draft safe-abstraction library to enhance safety of raw pointers](https://github.com/islet-project/islet/pull/298))_

## Target Structure
- RsiHostCall: Manaully Reviewed
- RsiRealmConfig: Manaully Reviewed