### PR TITLE
Fix return values in rmi features

### DIFF
--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -1,7 +1,6 @@
 use crate::event::Mainloop;
 use crate::listen;
 use crate::rmi;
-use crate::rmi::error::Error;
 
 extern crate alloc;
 
@@ -45,7 +44,7 @@ fn mask(shift: usize, width: usize) -> usize {
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::FEATURES, |arg, ret, _| {
         if arg[0] != FEATURE_REGISTER_0_INDEX {
-            return Err(Error::RmiErrorInput);
+            return Ok(());
         }
 
         let mut feat_reg0: usize = 0;

--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -44,6 +44,7 @@ fn mask(shift: usize, width: usize) -> usize {
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::FEATURES, |arg, ret, _| {
         if arg[0] != FEATURE_REGISTER_0_INDEX {
+            ret[1] = 0;
             return Ok(());
         }
 


### PR DESCRIPTION
This PR fixes one correctness bug, found by [model checking](https://en.wikipedia.org/wiki/Model_checking) ([relevant PR](https://github.com/islet-project/islet/pull/234)). It also explicitly assigns a value of zero to X1 for better understanding of RMI features' behavior.

## Related spec

[B3.3.4.2 in beta0 and B4.3.4.2 in eac5]
```
The RMI_FEATURES command does not have any failure conditions.
```

[B3.3.4.3 in beta0 and B4.3.4.3 in eac5]
```
pre: index != 0
post: X1 == Zero()
```


