### PR TITLE
Refactor constraint retrieval procedure

### DIFF
--- a/rmm/src/rmi/constraint.rs
+++ b/rmm/src/rmi/constraint.rs
@@ -1,8 +1,5 @@
-extern crate alloc;
-
 use crate::event::Command;
 use crate::rmi;
-use alloc::collections::btree_map::BTreeMap;
 
 #[allow(dead_code)]
 #[derive(Default, Copy, Clone)]
@@ -23,73 +20,37 @@ impl Constraint {
     }
 }
 
-lazy_static! {
-    static ref CONSTRAINTS: BTreeMap<Command, Constraint> = {
-        let mut m = BTreeMap::new();
-        m.insert(rmi::VERSION, Constraint::new(rmi::VERSION, 1, 1));
-        m.insert(
-            rmi::GRANULE_DELEGATE,
-            Constraint::new(rmi::GRANULE_DELEGATE, 2, 1),
-        );
-        m.insert(
-            rmi::GRANULE_UNDELEGATE,
-            Constraint::new(rmi::GRANULE_UNDELEGATE, 2, 1),
-        );
-        m.insert(rmi::DATA_CREATE, Constraint::new(rmi::DATA_CREATE, 6, 1));
-        m.insert(rmi::DATA_CREATE_UNKNOWN, Constraint::new(rmi::DATA_CREATE_UNKNOWN, 4, 1));
-        m.insert(rmi::DATA_DESTROY, Constraint::new(rmi::DATA_DESTROY, 3, 3));
-        m.insert(
-            rmi::REALM_ACTIVATE,
-            Constraint::new(rmi::REALM_ACTIVATE, 2, 1),
-        );
+fn pick(cmd: Command) -> Option<Constraint> {
+    let constraint = match cmd {
+        rmi::VERSION => Constraint::new(rmi::VERSION, 1, 1),
+        rmi::GRANULE_DELEGATE => Constraint::new(rmi::GRANULE_DELEGATE, 2, 1),
+        rmi::GRANULE_UNDELEGATE => Constraint::new(rmi::GRANULE_UNDELEGATE, 2, 1),
+        rmi::DATA_CREATE => Constraint::new(rmi::DATA_CREATE, 6, 1),
+        rmi::DATA_CREATE_UNKNOWN => Constraint::new(rmi::DATA_CREATE_UNKNOWN, 4, 1),
+        rmi::DATA_DESTROY => Constraint::new(rmi::DATA_DESTROY, 3, 3),
+        rmi::REALM_ACTIVATE => Constraint::new(rmi::REALM_ACTIVATE, 2, 1),
         // NOTE: REALM_CREATE has 3 of arg_num and 1 of ret_num according to the specification,
         //       but we're using one more return value for our own purpose.
-        m.insert(rmi::REALM_CREATE, Constraint::new(rmi::REALM_CREATE, 3, 2));
-        m.insert(
-            rmi::REALM_DESTROY,
-            Constraint::new(rmi::REALM_DESTROY, 2, 1),
-        );
+        rmi::REALM_CREATE => Constraint::new(rmi::REALM_CREATE, 3, 2),
+        rmi::REALM_DESTROY => Constraint::new(rmi::REALM_DESTROY, 2, 1),
         // NOTE: REC_CREATE has 4 of arg_num and 1 of ret_num according to the specification,
         //       but we're using one more return value for our own purpose.
-        m.insert(rmi::REC_CREATE, Constraint::new(rmi::REC_CREATE, 4, 2));
-        m.insert(rmi::REC_DESTROY, Constraint::new(rmi::REC_DESTROY, 4, 1));
-        m.insert(rmi::REC_ENTER, Constraint::new(rmi::REC_ENTER, 3, 1));
-        m.insert(
-            rmi::RTT_MAP_UNPROTECTED,
-            Constraint::new(rmi::RTT_MAP_UNPROTECTED, 5, 1),
-        );
-        m.insert(
-            rmi::RTT_UNMAP_UNPROTECTED,
-            Constraint::new(rmi::RTT_UNMAP_UNPROTECTED, 4, 1),
-        );
-        m.insert(
-            rmi::RTT_READ_ENTRY,
-            Constraint::new(rmi::RTT_READ_ENTRY, 4, 5),
-        );
-        m.insert(rmi::FEATURES, Constraint::new(rmi::FEATURES, 2, 2));
-        m.insert(
-            rmi::REC_AUX_COUNT,
-            Constraint::new(rmi::REC_AUX_COUNT, 2, 2),
-        );
-        m.insert(
-            rmi::RTT_CREATE,
-            Constraint::new(rmi::RTT_CREATE, 5, 1),
-        );
-        m.insert(
-            rmi::RTT_DESTROY,
-            Constraint::new(rmi::RTT_DESTROY, 5, 1),
-        );
-        m.insert(
-            rmi::RTT_INIT_RIPAS,
-            Constraint::new(rmi::RTT_INIT_RIPAS, 4, 2),
-        );
-        m.insert(
-            rmi::RTT_SET_RIPAS,
-            Constraint::new(rmi::RTT_SET_RIPAS, 6, 2),
-        );
-        m.insert(rmi::REQ_COMPLETE, Constraint::new(rmi::REQ_COMPLETE, 4, 2));
-        m
+        rmi::REC_CREATE => Constraint::new(rmi::REC_CREATE, 4, 2),
+        rmi::REC_DESTROY => Constraint::new(rmi::REC_DESTROY, 4, 1),
+        rmi::REC_ENTER => Constraint::new(rmi::REC_ENTER, 3, 1),
+        rmi::RTT_MAP_UNPROTECTED => Constraint::new(rmi::RTT_MAP_UNPROTECTED, 5, 1),
+        rmi::RTT_UNMAP_UNPROTECTED => Constraint::new(rmi::RTT_UNMAP_UNPROTECTED, 4, 1),
+        rmi::RTT_READ_ENTRY => Constraint::new(rmi::RTT_READ_ENTRY, 4, 5),
+        rmi::FEATURES => Constraint::new(rmi::FEATURES, 2, 2),
+        rmi::REC_AUX_COUNT => Constraint::new(rmi::REC_AUX_COUNT, 2, 2),
+        rmi::RTT_CREATE => Constraint::new(rmi::RTT_CREATE, 5, 1),
+        rmi::RTT_DESTROY => Constraint::new(rmi::RTT_DESTROY, 5, 1),
+        rmi::RTT_INIT_RIPAS => Constraint::new(rmi::RTT_INIT_RIPAS, 4, 2),
+        rmi::RTT_SET_RIPAS => Constraint::new(rmi::RTT_SET_RIPAS, 6, 2),
+        rmi::REQ_COMPLETE => Constraint::new(rmi::REQ_COMPLETE, 4, 2),
+        _ => return None,
     };
+    Some(constraint)
 }
 
 pub fn validate<T, G>(cmd: Command, ok_func: T, else_func: G)
@@ -97,7 +58,7 @@ where
     T: Fn(usize, usize),
     G: FnOnce(), // TODO: error command?
 {
-    if let Some(c) = CONSTRAINTS.get(&cmd) {
+    if let Some(c) = pick(cmd) {
         // TODO: command-specific validation routine if needed
         ok_func(c.arg_num, c.ret_num);
     } else {

--- a/rmm/src/rsi/constraint.rs
+++ b/rmm/src/rsi/constraint.rs
@@ -1,82 +1,37 @@
-extern crate alloc;
-
 use crate::event::Command;
 use crate::rmi::constraint::Constraint; // TODO: we might need rsi's own constraint struct in the future
 use crate::rsi;
 use crate::rsi::psci;
-use alloc::collections::btree_map::BTreeMap;
 
-lazy_static! {
-    static ref CONSTRAINTS: BTreeMap<Command, Constraint> = {
-        let mut m = BTreeMap::new();
-        m.insert(
-            rsi::IPA_STATE_SET,
-            Constraint::new(rsi::IPA_STATE_SET, 2, 1),
-        );
-        m.insert(rsi::HOST_CALL, Constraint::new(rsi::HOST_CALL, 2, 1));
-        m.insert(rsi::ABI_VERSION, Constraint::new(rsi::ABI_VERSION, 2, 1));
-        m.insert(rsi::REALM_CONFIG, Constraint::new(rsi::REALM_CONFIG, 2, 1));
-        m.insert(
-            rsi::IPA_STATE_GET,
-            Constraint::new(rsi::IPA_STATE_GET, 2, 1),
-        );
-        m.insert(
-            psci::PSCI_VERSION,
-            Constraint::new(psci::PSCI_VERSION, 2, 1),
-        );
-        m.insert(
-            psci::SMC32::CPU_SUSPEND,
-            Constraint::new(psci::SMC32::CPU_SUSPEND, 2, 1),
-        );
-        m.insert(
-            psci::SMC64::CPU_SUSPEND,
-            Constraint::new(psci::SMC64::CPU_SUSPEND, 2, 1),
-        );
-        m.insert(
-            psci::SMC32::CPU_OFF,
-            Constraint::new(psci::SMC32::CPU_OFF, 2, 1),
-        );
-        m.insert(
-            psci::SMC32::CPU_ON,
-            Constraint::new(psci::SMC32::CPU_ON, 2, 1),
-        );
-        m.insert(
-            psci::SMC64::CPU_ON,
-            Constraint::new(psci::SMC64::CPU_ON, 2, 1),
-        );
-        m.insert(
-            psci::SMC32::AFFINITY_INFO,
-            Constraint::new(psci::SMC32::AFFINITY_INFO, 2, 1),
-        );
-        m.insert(
-            psci::SMC64::AFFINITY_INFO,
-            Constraint::new(psci::SMC64::AFFINITY_INFO, 2, 1),
-        );
-        m.insert(
-            psci::SMC32::SYSTEM_OFF,
-            Constraint::new(psci::SMC32::SYSTEM_OFF, 2, 1),
-        );
-        m.insert(
-            psci::SMC32::SYSTEM_RESET,
-            Constraint::new(psci::SMC32::SYSTEM_RESET, 2, 1),
-        );
-        m.insert(
-            psci::SMC32::FEATURES,
-            Constraint::new(psci::SMC32::FEATURES, 2, 1),
-        );
-        m.insert(
-            psci::SMCCC_VERSION,
-            Constraint::new(psci::SMCCC_VERSION, 2, 1),
-        );
-        m
+fn pick(cmd: Command) -> Option<Constraint> {
+    let constraint = match cmd {
+        rsi::IPA_STATE_SET => Constraint::new(rsi::IPA_STATE_SET, 2, 1),
+        rsi::HOST_CALL => Constraint::new(rsi::HOST_CALL, 2, 1),
+        rsi::ABI_VERSION => Constraint::new(rsi::ABI_VERSION, 2, 1),
+        rsi::REALM_CONFIG => Constraint::new(rsi::REALM_CONFIG, 2, 1),
+        rsi::IPA_STATE_GET => Constraint::new(rsi::IPA_STATE_GET, 2, 1),
+        psci::PSCI_VERSION => Constraint::new(psci::PSCI_VERSION, 2, 1),
+        psci::SMC32::CPU_SUSPEND => Constraint::new(psci::SMC32::CPU_SUSPEND, 2, 1),
+        psci::SMC64::CPU_SUSPEND => Constraint::new(psci::SMC64::CPU_SUSPEND, 2, 1),
+        psci::SMC32::CPU_OFF => Constraint::new(psci::SMC32::CPU_OFF, 2, 1),
+        psci::SMC32::CPU_ON => Constraint::new(psci::SMC32::CPU_ON, 2, 1),
+        psci::SMC64::CPU_ON => Constraint::new(psci::SMC64::CPU_ON, 2, 1),
+        psci::SMC32::AFFINITY_INFO => Constraint::new(psci::SMC32::AFFINITY_INFO, 2, 1),
+        psci::SMC64::AFFINITY_INFO => Constraint::new(psci::SMC64::AFFINITY_INFO, 2, 1),
+        psci::SMC32::SYSTEM_OFF => Constraint::new(psci::SMC32::SYSTEM_OFF, 2, 1),
+        psci::SMC32::SYSTEM_RESET => Constraint::new(psci::SMC32::SYSTEM_RESET, 2, 1),
+        psci::SMC32::FEATURES => Constraint::new(psci::SMC32::FEATURES, 2, 1),
+        psci::SMCCC_VERSION => Constraint::new(psci::SMCCC_VERSION, 2, 1),
+        _ => return None,
     };
+    Some(constraint)
 }
 
 pub fn validate<T>(cmd: Command, mut ok_func: T)
 where
     T: FnMut(usize, usize),
 {
-    if let Some(c) = CONSTRAINTS.get(&cmd) {
+    if let Some(c) = pick(cmd) {
         ok_func(c.arg_num, c.ret_num);
     } else {
         // rsi.dispatch takes care of unregistered command.


### PR DESCRIPTION
This PR refactors constraint retrieval procedure of RMI and RSI. The main motivation of the refactoring is that insertion & get in the map are very expensive operations especially in the formal semantic and avoiding them is better if possible. It would be also beneficial for runtime performance, as the previous insertions are no longer involved. The change assumes that the configuration regarding constraints does not change at runtime.

[before]
```
lazy_static! {
    static ref CONSTRAINTS: BTreeMap<Command, Constraint> = {
        let mut m = BTreeMap::new();
        m.insert(rmi::VERSION, Constraint::new(rmi::VERSION, 1, 1));
...
(caller)
     if let Some(c) = CONSTRAINTS.get(&cmd) {
```

[after]
```
fn pick(cmd: Command) -> Option<Constraint> {
    let constraint = match cmd {
        rmi::VERSION => Constraint::new(rmi::VERSION, 1, 1),
...
(caller)
    if let Some(c) = pick(cmd) {
```


