### PR TITLE
ci: Add cargo vet to ensure that 3rd-party deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,12 @@ jobs:
     - name: Check pylint
       run: ./scripts/pylint.sh
 
+    - name: Check third-party Rust dependencies
+      run: |
+        cargo install --locked cargo-vet
+        cargo vet init
+        cargo vet
+
     - uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR applies `cargo-vet` to CI

ref) https://mozilla.github.io/cargo-vet/