### PR TITLE
ci: Cache assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/cache@v3
+        with:
+          path: .git/modules/assets
+          key: ${{ runner.os }}-assets-${{ hashFiles('.gitmodules', 'assets') }}
+
       - name: Install dependencies
         run: ./scripts/init_min_acs.sh
 
@@ -83,6 +88,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/cache@v3
+        with:
+          path: .git/modules/assets
+          key: ${{ runner.os }}-assets-${{ hashFiles('.gitmodules', 'assets') }}
+
       - name: Install dependencies
         run: ./scripts/init_min.sh
 
@@ -99,6 +109,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: actions/cache@v3
+      with:
+        path: .git/modules/assets
+        key: ${{ runner.os }}-assets-${{ hashFiles('.gitmodules', 'assets') }}
+
     - name: Install dependencies
       run: |
         ./scripts/deps/assets.sh
@@ -113,6 +128,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+
+    - uses: actions/cache@v3
+      with:
+        path: .git/modules/assets
+        key: ${{ runner.os }}-assets-${{ hashFiles('.gitmodules', 'assets') }}
 
     - name: Install dependencies
       run: |
@@ -152,6 +172,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: actions/cache@v3
+      with:
+        path: .git/modules/assets
+        key: ${{ runner.os }}-assets-${{ hashFiles('.gitmodules', 'assets') }}
+
     - name: Install dependencies
       run: |
         ./scripts/deps/assets.sh
@@ -182,6 +207,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - uses: actions/cache@v3
+      with:
+        path: .git/modules/assets
+        key: ${{ runner.os }}-assets-${{ hashFiles('.gitmodules', 'assets') }}
+
     - name: Install dependencies
       run: |
         ./scripts/deps/assets.sh
@@ -195,6 +225,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+
+    - uses: actions/cache@v3
+      with:
+        path: .git/modules/assets
+        key: ${{ runner.os }}-assets-${{ hashFiles('.gitmodules', 'assets') }}
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This PR applies caching for the `assets` directory within our github action workflow.
This change results about 5 minutes reduction when it takes to download the entire assets.