### PR TITLE
3rd: Pin serde version to fix the build-error 

### DIFF
--- a/scripts/deps/cross.sh
+++ b/scripts/deps/cross.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-cargo install cross --git https://github.com/cross-rs/cross
+cargo install cross --git https://github.com/bitboom/cross
 sudo systemctl start docker


### PR DESCRIPTION
This PR resolves the `serde` compatibility issue.

```
   Compiling serde v1.0.198
error[E0658]: use of unstable library feature 'saturating_int_impl'
   --> /home/sangwan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.198/src/lib.rs:279:13
    |
279 |     pub use self::core::num::Saturating;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #87920 <https://github.com/rust-lang/rust/issues/87920> for more information
    = help: add `#![feature(saturating_int_impl)]` to the crate attributes t
```