### PR TITLE
Do not miss content wiping in granule undelegate

### DIFF
--- a/rmm/src/granule/array/entry.rs
+++ b/rmm/src/granule/array/entry.rs
@@ -22,7 +22,10 @@ impl Granule {
     }
 
     pub fn set_state(&mut self, state: u8) -> Result<(), Error> {
-        if state == GranuleState::Delegated {
+        let prev = self.state;
+        if (prev == GranuleState::Delegated && state == GranuleState::Undelegated)
+            || (state == GranuleState::Delegated)
+        {
             self.zeroize();
         }
         self.state = state;


### PR DESCRIPTION
This PR fixes a bug in `granule_undelegate`, found by model checking. Note that the previous page table-based GST didn't contain this bug.

[B.3.3.6.3 Success conditions in beta0 (B.4.3.6.3 in eac5)]
```
ID                 Condition
...
gran_content       Contents of target Granule are wiped.
```