### PR TITLE
ci: Fix the error related with installing packages

### DIFF
--- a/scripts/deps/pkgs.sh
+++ b/scripts/deps/pkgs.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-apt update && apt -y install sudo
+apt-get update && apt -y install sudo
 
-sudo apt install -y -qq --no-install-recommends \
+sudo apt-get update
+
+sudo apt-get install -y -qq --no-install-recommends --fix-missing \
 	gcc-multilib g++-multilib cmake libssl-dev \
 	binutils python3-pip \
 	device-tree-compiler xterm fakeroot mtools fdisk cpio \


### PR DESCRIPTION
This PR fixes [the CI error](https://github.com/islet-project/islet/actions/runs/8776046268/job/24079464476).

- Apply `sudo apt update` with `--fix-missing` which addressed issues caused by missing packages sources
- Fix to use `apt-get` which provides a stable CLI interface for automated environments