### PR TITLE
Fix data aborts related to RTT base

### DIFF
--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -78,7 +78,10 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let id = rd_obj.id();
         let rtt_base = rd_obj.rtt_base();
         // The below is added to avoid a fault regarding the RTT entry
-        PageTable::get_ref().map(rtt_base, true);
+        for i in 0..params.rtt_num_start as usize {
+            let rtt = rtt_base + i * GRANULE_SIZE;
+            PageTable::get_ref().map(rtt, true);
+        }
 
         rd_obj.set_hash_algo(params.hash_algo);
 


### PR DESCRIPTION
This PR fixes page table mapping related to RTT base. Note that `rtt_num_start` indicates the number of physically contiguous starting level RTTs. The patch connects the correct number of RTTs in the page table during realm creation. As a result, the unnecessary faults related to those addresses would not be generated in realm-linux booting.

```
[before]
...
[TRACE]islet_rmm::event -- RMI: REC_AUX_COUNT        [882E99000] > [0, 10]
[DEBUG]islet_rmm::exception::trap::syndrome -- Data Abort without a change in Exception level
[DEBUG]islet_rmm::exception::trap -- Data Abort (higher), far:881BC2000
[DEBUG]islet_rmm::exception::trap -- translation, level:3, esr:96000007
[TRACE]islet_rmm::event -- RMI: RTT_INIT_RIPAS       [882E99000, 80000000, 3] > [204, 0]
...
[TRACE]islet_rmm::event -- RMI: REC_ENTER            [882D9F000, 882D9E000] > [0]
[DEBUG]islet_rmm::exception::trap::syndrome -- Data Abort without a change in Exception level
[DEBUG]islet_rmm::exception::trap -- Data Abort (higher), far:881BC6310
[DEBUG]islet_rmm::exception::trap -- translation, level:3, esr:96000007
[TRACE]islet_rmm::event -- RMI: RTT_MAP_UNPROTECTED  [882E99000, 18C460000, 3, 88FEDB3D8] > [204]
...

[after]
...
[TRACE]islet_rmm::event -- RMI: REC_AUX_COUNT        [880392000] > [0, 10]
[TRACE]islet_rmm::event -- RMI: RTT_INIT_RIPAS       [880392000, 80000000, 3] > [204, 0]
...
[TRACE]islet_rmm::event -- RMI: REC_ENTER            [881F88000, 881038000] > [0]
[TRACE]islet_rmm::event -- RMI: RTT_MAP_UNPROTECTED  [880392000, 18C460000, 3, 88D9B43D8] > [204]
...
```