### PR TITLE
safe-abstraction: Add Error Code

### DIFF
--- a/rmm/src/host/mod.rs
+++ b/rmm/src/host/mod.rs
@@ -14,7 +14,14 @@ pub fn copy_from<T: SafetyChecked + SafetyAssured + Copy>(addr: usize) -> Option
     PageTable::get_ref().map(addr, false);
     let ret = assume_safe::<T>(addr).map(|safety_assumed| *safety_assumed);
     PageTable::get_ref().unmap(addr);
-    ret
+
+    match ret {
+        Ok(obj) => Some(obj),
+        Err(err) => {
+            error!("Failed to convert a raw pointer to the struct. {:?}", err);
+            None
+        }
+    }
 }
 
 pub fn copy_to<T: SafetyChecked + SafetyAssured + Copy>(src: &T, dst: usize) -> Option<()> {
@@ -25,7 +32,14 @@ pub fn copy_to<T: SafetyChecked + SafetyAssured + Copy>(src: &T, dst: usize) -> 
     PageTable::get_ref().map(dst, false);
     let ret = assume_safe::<T>(dst).map(|mut safety_assumed| *safety_assumed = *src);
     PageTable::get_ref().unmap(dst);
-    ret
+
+    match ret {
+        Ok(_) => Some(()),
+        Err(err) => {
+            error!("Failed to convert a raw pointer to the struct. {:?}", err);
+            None
+        }
+    }
 }
 
 /// DataPage is used to convey realm data from host to realm.

--- a/rmm/src/realm/config.rs
+++ b/rmm/src/realm/config.rs
@@ -20,9 +20,8 @@ impl RealmConfig {
     // `console=ttyS0 root=/dev/vda rw  console=pl011,mmio,0x1c0a0000 console=ttyAMA0 printk.devkmsg=on`.
     // So, we get back to use the same kernel argument with TF-RMM's one (uart0 & uart3).
     pub fn init(config_addr: usize, ipa_width: usize) -> Result<(), Error> {
-        assume_safe::<RealmConfig>(config_addr)
-            .map(|mut realm_config| realm_config.ipa_width = ipa_width)
-            .ok_or(Error::RmiErrorInput)
+        Ok(assume_safe::<RealmConfig>(config_addr)
+            .map(|mut realm_config| realm_config.ipa_width = ipa_width)?)
     }
 }
 

--- a/rmm/src/rmi/error.rs
+++ b/rmm/src/rmi/error.rs
@@ -1,5 +1,7 @@
 use crate::{measurement::MeasurementError, rsi};
 
+use safe_abstraction::raw_ptr;
+
 // B3.4.1 RmiCommandReturnCode type
 // Default index is 0
 #[derive(Debug)]
@@ -57,5 +59,12 @@ impl From<rsi::error::Error> for Error {
             }
             _ => Self::RmiErrorOthers(InternalError::InvalidMeasurementIndex),
         }
+    }
+}
+
+impl From<raw_ptr::Error> for Error {
+    fn from(error: raw_ptr::Error) -> Self {
+        error!("Failed to convert a raw pointer to the struct. {:?}", error);
+        Error::RmiErrorInput
     }
 }

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -74,7 +74,7 @@ pub fn do_host_call(
         )
         .ok_or(Error::RmiErrorInput)?;
 
-    let mut host_call = assume_safe::<HostCall>(pa.into()).ok_or(Error::RmiErrorInput)?;
+    let mut host_call = assume_safe::<HostCall>(pa.into())?;
     let imm = host_call.imm();
 
     if rec.host_call_pending() {


### PR DESCRIPTION
This PR adds `Error` to `safe-abstraction`. 

- Reflected [review](https://github.com/islet-project/islet/pull/290#discussion_r1552693060)
- Followed PR: [Fix structures, passed from host, to use safe abstraction](https://github.com/islet-project/islet/pull/297)