### PR TITLE
Integrate realm and rd

### DIFF
--- a/rmm/src/exception/lower/synchronous/sys_reg.rs
+++ b/rmm/src/exception/lower/synchronous/sys_reg.rs
@@ -1,5 +1,4 @@
 use crate::exception::trap;
-use crate::realm::context::Context;
 use crate::realm::vcpu::VCPU;
 
 use armv9a::regs::*;
@@ -9,14 +8,14 @@ fn check_sysreg_id_access(esr: u64) -> bool {
     (esr.get_masked(ISS::Op0) | esr.get_masked(ISS::Op1) | esr.get_masked(ISS::CRn)) == ISS::Op0
 }
 
-pub fn handle(vcpu: &mut VCPU<Context>, esr: u64) -> u64 {
+pub fn handle(vcpu: &mut VCPU, esr: u64) -> u64 {
     if check_sysreg_id_access(esr) {
         handle_sysreg_id(vcpu, esr);
     }
     trap::RET_TO_REC
 }
 
-fn handle_sysreg_id(vcpu: &mut VCPU<Context>, esr: u64) -> u64 {
+fn handle_sysreg_id(vcpu: &mut VCPU, esr: u64) -> u64 {
     let esr = ISS::new(esr);
     let il = esr.get_masked_value(ISS::IL);
     let rt = esr.get_masked_value(ISS::Rt) as usize;

--- a/rmm/src/exception/trap.rs
+++ b/rmm/src/exception/trap.rs
@@ -8,7 +8,6 @@ use super::lower::synchronous;
 use crate::cpu;
 use crate::event::realmexit::{ExitSyncType, RecExitReason};
 use crate::mm::translation::PageTable;
-use crate::realm::context::Context;
 use crate::realm::vcpu::VCPU;
 
 use armv9a::regs::*;
@@ -142,7 +141,7 @@ pub const RET_TO_RMM: u64 = 1;
 pub extern "C" fn handle_lower_exception(
     info: Info,
     esr: u32,
-    vcpu: &mut VCPU<Context>,
+    vcpu: &mut VCPU,
     tf: &mut TrapFrame,
 ) -> u64 {
     match info.kind {
@@ -242,6 +241,6 @@ pub extern "C" fn handle_lower_exception(
 }
 
 #[inline(always)]
-fn advance_pc(vcpu: &mut VCPU<Context>) {
+fn advance_pc(vcpu: &mut VCPU) {
     vcpu.context.elr += 4;
 }

--- a/rmm/src/gic.rs
+++ b/rmm/src/gic.rs
@@ -1,7 +1,7 @@
-use crate::realm::registry::get_realm;
 use crate::realm::vcpu::VCPU;
 use crate::rmi::error::Error;
 use crate::rmi::error::InternalError::*;
+use crate::rmi::realm::Rd;
 use crate::rmi::rec::run::Run;
 
 use armv9a::regs::*;
@@ -231,10 +231,8 @@ pub fn save_state(vcpu: &mut VCPU) {
     unsafe { ICH_HCR_EL2.set(gic_state.ich_hcr_el2 & !ICH_HCR_EL2_EN_BIT) };
 }
 
-pub fn receive_state_from_host(id: usize, vcpu: usize, run: &Run) -> Result<(), Error> {
-    let realm = get_realm(id).ok_or(Error::RmiErrorOthers(NotExistRealm))?;
-    let locked_realm = realm.lock();
-    let vcpu = locked_realm
+pub fn receive_state_from_host(rd: &Rd, vcpu: usize, run: &Run) -> Result<(), Error> {
+    let vcpu = rd
         .vcpus
         .get(vcpu)
         .ok_or(Error::RmiErrorOthers(NotExistVCPU))?;
@@ -247,10 +245,8 @@ pub fn receive_state_from_host(id: usize, vcpu: usize, run: &Run) -> Result<(), 
     Ok(())
 }
 
-pub fn send_state_to_host(id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error> {
-    let realm = get_realm(id).ok_or(Error::RmiErrorOthers(NotExistRealm))?;
-    let mut locked_realm = realm.lock();
-    let vcpu = locked_realm
+pub fn send_state_to_host(rd: &mut Rd, vcpu: usize, run: &mut Run) -> Result<(), Error> {
+    let vcpu = rd
         .vcpus
         .get_mut(vcpu)
         .ok_or(Error::RmiErrorOthers(NotExistVCPU))?;

--- a/rmm/src/gic.rs
+++ b/rmm/src/gic.rs
@@ -1,4 +1,3 @@
-use crate::realm::context::Context;
 use crate::realm::registry::get_realm;
 use crate::realm::vcpu::VCPU;
 use crate::rmi::error::Error;
@@ -84,7 +83,7 @@ lazy_static! {
     };
 }
 
-pub fn init_gic(vcpu: &mut VCPU<Context>) {
+pub fn init_gic(vcpu: &mut VCPU) {
     let gic_state = &mut vcpu.context.gic_state;
     gic_state.ich_hcr_el2 =
         ICH_HCR_EL2_EN_BIT | ICH_HCR_EL2_VSGIEEOICOUNT_BIT | ICH_HCR_EL2_DVIM_BIT
@@ -196,7 +195,7 @@ fn get_ap1r(i: usize) -> u64 {
     }
 }
 
-pub fn restore_state(vcpu: &VCPU<Context>) {
+pub fn restore_state(vcpu: &VCPU) {
     let gic_state = &vcpu.context.gic_state;
     let nr_lrs = GIC_FEATURES.nr_lrs;
     let nr_aprs = GIC_FEATURES.nr_aprs;
@@ -212,7 +211,7 @@ pub fn restore_state(vcpu: &VCPU<Context>) {
     unsafe { ICH_HCR_EL2.set(gic_state.ich_hcr_el2) };
 }
 
-pub fn save_state(vcpu: &mut VCPU<Context>) {
+pub fn save_state(vcpu: &mut VCPU) {
     let gic_state = &mut vcpu.context.gic_state;
     let nr_lrs = GIC_FEATURES.nr_lrs;
     let nr_aprs = GIC_FEATURES.nr_aprs;

--- a/rmm/src/mmio.rs
+++ b/rmm/src/mmio.rs
@@ -1,13 +1,11 @@
-use crate::realm::registry::get_realm;
 use crate::rmi::error::Error;
 use crate::rmi::error::InternalError::*;
+use crate::rmi::realm::Rd;
 use crate::rmi::rec::run::{Run, REC_ENTRY_FLAG_EMUL_MMIO};
 use armv9a::regs::*;
 
-pub fn emulate_mmio(id: usize, vcpu: usize, run: &Run) -> Result<(), Error> {
-    let realm = get_realm(id).ok_or(Error::RmiErrorOthers(NotExistRealm))?;
-    let mut locked_realm = realm.lock();
-    let vcpu = locked_realm
+pub fn emulate_mmio(rd: &mut Rd, vcpu: usize, run: &Run) -> Result<(), Error> {
+    let vcpu = rd
         .vcpus
         .get_mut(vcpu)
         .ok_or(Error::RmiErrorOthers(NotExistVCPU))?;

--- a/rmm/src/realm/config.rs
+++ b/rmm/src/realm/config.rs
@@ -1,7 +1,6 @@
 use crate::realm::mm::address::GuestPhysAddr;
-use crate::realm::registry::get_realm;
 use crate::rmi::error::Error;
-use crate::rmi::error::InternalError::*;
+use crate::rmi::realm::Rd;
 use crate::rmi::rtt::RTT_PAGE_LEVEL;
 
 use safe_abstraction::raw_ptr::assume_safe;
@@ -25,11 +24,9 @@ impl RealmConfig {
     }
 }
 
-pub fn realm_config(id: usize, config_ipa: usize, ipa_bits: usize) -> Result<(), Error> {
-    let res = get_realm(id)
-        .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-        .lock()
-        .page_table
+pub fn realm_config(rd: &Rd, config_ipa: usize, ipa_bits: usize) -> Result<(), Error> {
+    let res = rd
+        .s2_table()
         .lock()
         .ipa_to_pa(GuestPhysAddr::from(config_ipa), RTT_PAGE_LEVEL);
     if let Some(pa) = res {

--- a/rmm/src/realm/context.rs
+++ b/rmm/src/realm/context.rs
@@ -93,8 +93,8 @@ pub fn get_reg(id: usize, vcpu: usize, register: usize) -> Result<usize, Error> 
     }
 }
 
-impl crate::realm::vcpu::Context for Context {
-    fn new() -> Self {
+impl Context {
+    pub fn new() -> Self {
         // Set appropriate sys registers
         // TODO: enable floating point
         // CPTR_EL2, CPACR_EL1, update vectors.s, etc..
@@ -104,7 +104,7 @@ impl crate::realm::vcpu::Context for Context {
         }
     }
 
-    unsafe fn into_current(vcpu: &mut VCPU<Self>) {
+    pub unsafe fn into_current(vcpu: &mut VCPU) {
         vcpu.pcpu = Some(get_cpu_id());
         vcpu.context.sys_regs.vmpidr = vcpu.pcpu.unwrap() as u64;
         TPIDR_EL2.set(vcpu as *const _ as u64);
@@ -112,7 +112,7 @@ impl crate::realm::vcpu::Context for Context {
         timer::restore_state(vcpu);
     }
 
-    unsafe fn from_current(vcpu: &mut VCPU<Self>) {
+    pub unsafe fn from_current(vcpu: &mut VCPU) {
         gic::save_state(vcpu);
         timer::save_state(vcpu);
         vcpu.pcpu = None;

--- a/rmm/src/realm/context.rs
+++ b/rmm/src/realm/context.rs
@@ -1,10 +1,10 @@
 use super::timer;
 use crate::cpu::get_cpu_id;
 use crate::gic;
-use crate::realm::registry::get_realm;
 use crate::realm::vcpu::VCPU;
 use crate::rmi::error::Error;
 use crate::rmi::error::InternalError::*;
+use crate::rmi::realm::Rd;
 
 use armv9a::regs::*;
 
@@ -20,13 +20,10 @@ pub struct Context {
     pub fp_regs: [u128; 32],
 }
 
-pub fn set_reg(id: usize, vcpu: usize, register: usize, value: usize) -> Result<(), Error> {
+pub fn set_reg(rd: &Rd, vcpu: usize, register: usize, value: usize) -> Result<(), Error> {
     match register {
         0..=30 => {
-            get_realm(id)
-                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                .lock()
-                .vcpus
+            rd.vcpus
                 .get(vcpu)
                 .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
                 .lock()
@@ -35,10 +32,7 @@ pub fn set_reg(id: usize, vcpu: usize, register: usize, value: usize) -> Result<
             Ok(())
         }
         31 => {
-            get_realm(id)
-                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                .lock()
-                .vcpus
+            rd.vcpus
                 .get(vcpu)
                 .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
                 .lock()
@@ -47,10 +41,7 @@ pub fn set_reg(id: usize, vcpu: usize, register: usize, value: usize) -> Result<
             Ok(())
         }
         32 => {
-            get_realm(id)
-                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                .lock()
-                .vcpus
+            rd.vcpus
                 .get(vcpu)
                 .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
                 .lock()
@@ -63,12 +54,10 @@ pub fn set_reg(id: usize, vcpu: usize, register: usize, value: usize) -> Result<
     Ok(())
 }
 
-pub fn get_reg(id: usize, vcpu: usize, register: usize) -> Result<usize, Error> {
+pub fn get_reg(rd: &Rd, vcpu: usize, register: usize) -> Result<usize, Error> {
     match register {
         0..=30 => {
-            let value = get_realm(id)
-                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                .lock()
+            let value = rd
                 .vcpus
                 .get(vcpu)
                 .ok_or(Error::RmiErrorOthers(NotExistVCPU))?
@@ -78,9 +67,7 @@ pub fn get_reg(id: usize, vcpu: usize, register: usize) -> Result<usize, Error> 
             Ok(value as usize)
         }
         31 => {
-            let value = get_realm(id)
-                .ok_or(Error::RmiErrorOthers(NotExistRealm))?
-                .lock()
+            let value = rd
                 .vcpus
                 .get(vcpu)
                 .ok_or(Error::RmiErrorOthers(NotExistVCPU))?

--- a/rmm/src/realm/mod.rs
+++ b/rmm/src/realm/mod.rs
@@ -21,7 +21,6 @@ extern crate alloc;
 pub struct Realm<T: Context> {
     id: usize,
     pub vmid: u16,
-    pub state: State,
     pub vcpus: Vec<Arc<Mutex<VCPU<T>>>>,
     pub page_table: Arc<Mutex<Box<dyn IPATranslation>>>,
     pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
@@ -38,7 +37,6 @@ impl<T: Context + Default> Realm<T> {
             Mutex::new(Self {
                 id,
                 vmid,
-                state: State::New,
                 vcpus,
                 page_table,
                 measurements: [Measurement::empty(); MEASUREMENTS_SLOT_NR],
@@ -51,12 +49,4 @@ impl<T: Context> Drop for Realm<T> {
     fn drop(&mut self) {
         info!("Realm #{} was destroyed!", self.id);
     }
-}
-
-#[derive(Debug)]
-pub enum State {
-    Null,
-    New,
-    Active,
-    SystemOff,
 }

--- a/rmm/src/realm/mod.rs
+++ b/rmm/src/realm/mod.rs
@@ -6,10 +6,8 @@ pub mod timer;
 pub mod vcpu;
 
 use crate::measurement::{Measurement, MEASUREMENTS_SLOT_NR};
-use crate::realm::mm::IPATranslation;
 use crate::realm::vcpu::{Context, VCPU};
 
-use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
@@ -22,23 +20,17 @@ pub struct Realm<T: Context> {
     id: usize,
     pub vmid: u16,
     pub vcpus: Vec<Arc<Mutex<VCPU<T>>>>,
-    pub page_table: Arc<Mutex<Box<dyn IPATranslation>>>,
     pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
 }
 
 impl<T: Context + Default> Realm<T> {
-    pub fn new(
-        id: usize,
-        vmid: u16,
-        page_table: Arc<Mutex<Box<dyn IPATranslation>>>,
-    ) -> Arc<Mutex<Self>> {
+    pub fn new(id: usize, vmid: u16) -> Arc<Mutex<Self>> {
         Arc::new({
             let vcpus = Vec::new();
             Mutex::new(Self {
                 id,
                 vmid,
                 vcpus,
-                page_table,
                 measurements: [Measurement::empty(); MEASUREMENTS_SLOT_NR],
             })
         })

--- a/rmm/src/realm/mod.rs
+++ b/rmm/src/realm/mod.rs
@@ -5,10 +5,7 @@ pub mod registry;
 pub mod timer;
 pub mod vcpu;
 
-use crate::realm::vcpu::VCPU;
-
 use alloc::sync::Arc;
-use alloc::vec::Vec;
 use core::fmt::Debug;
 use spin::mutex::Mutex;
 
@@ -18,15 +15,11 @@ extern crate alloc;
 pub struct Realm {
     id: usize,
     pub vmid: u16,
-    pub vcpus: Vec<Arc<Mutex<VCPU>>>,
 }
 
 impl Realm {
     pub fn new(id: usize, vmid: u16) -> Arc<Mutex<Self>> {
-        Arc::new({
-            let vcpus = Vec::new();
-            Mutex::new(Self { id, vmid, vcpus })
-        })
+        Arc::new(Mutex::new(Self { id, vmid }))
     }
 }
 

--- a/rmm/src/realm/mod.rs
+++ b/rmm/src/realm/mod.rs
@@ -5,7 +5,7 @@ pub mod registry;
 pub mod timer;
 pub mod vcpu;
 
-use crate::realm::vcpu::{Context, VCPU};
+use crate::realm::vcpu::VCPU;
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -15,13 +15,13 @@ use spin::mutex::Mutex;
 extern crate alloc;
 
 #[derive(Debug)]
-pub struct Realm<T: Context> {
+pub struct Realm {
     id: usize,
     pub vmid: u16,
-    pub vcpus: Vec<Arc<Mutex<VCPU<T>>>>,
+    pub vcpus: Vec<Arc<Mutex<VCPU>>>,
 }
 
-impl<T: Context + Default> Realm<T> {
+impl Realm {
     pub fn new(id: usize, vmid: u16) -> Arc<Mutex<Self>> {
         Arc::new({
             let vcpus = Vec::new();
@@ -30,7 +30,7 @@ impl<T: Context + Default> Realm<T> {
     }
 }
 
-impl<T: Context> Drop for Realm<T> {
+impl Drop for Realm {
     fn drop(&mut self) {
         info!("Realm #{} was destroyed!", self.id);
     }

--- a/rmm/src/realm/mod.rs
+++ b/rmm/src/realm/mod.rs
@@ -5,7 +5,6 @@ pub mod registry;
 pub mod timer;
 pub mod vcpu;
 
-use crate::measurement::{Measurement, MEASUREMENTS_SLOT_NR};
 use crate::realm::vcpu::{Context, VCPU};
 
 use alloc::sync::Arc;
@@ -20,19 +19,13 @@ pub struct Realm<T: Context> {
     id: usize,
     pub vmid: u16,
     pub vcpus: Vec<Arc<Mutex<VCPU<T>>>>,
-    pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
 }
 
 impl<T: Context + Default> Realm<T> {
     pub fn new(id: usize, vmid: u16) -> Arc<Mutex<Self>> {
         Arc::new({
             let vcpus = Vec::new();
-            Mutex::new(Self {
-                id,
-                vmid,
-                vcpus,
-                measurements: [Measurement::empty(); MEASUREMENTS_SLOT_NR],
-            })
+            Mutex::new(Self { id, vmid, vcpus })
         })
     }
 }

--- a/rmm/src/realm/mod.rs
+++ b/rmm/src/realm/mod.rs
@@ -4,27 +4,3 @@ pub mod mm;
 pub mod registry;
 pub mod timer;
 pub mod vcpu;
-
-use alloc::sync::Arc;
-use core::fmt::Debug;
-use spin::mutex::Mutex;
-
-extern crate alloc;
-
-#[derive(Debug)]
-pub struct Realm {
-    id: usize,
-    pub vmid: u16,
-}
-
-impl Realm {
-    pub fn new(id: usize, vmid: u16) -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new(Self { id, vmid }))
-    }
-}
-
-impl Drop for Realm {
-    fn drop(&mut self) {
-        info!("Realm #{} was destroyed!", self.id);
-    }
-}

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -1,14 +1,4 @@
-use crate::realm::Realm;
-
-use alloc::collections::BTreeMap;
-use alloc::sync::Arc;
-use spin::mutex::Mutex;
+use alloc::collections::BTreeSet;
 use spinning_top::Spinlock;
 
-type RealmMutex = Arc<Mutex<Realm>>;
-type RealmMap = BTreeMap<usize, RealmMutex>;
-pub static RMS: Spinlock<(usize, RealmMap)> = Spinlock::new((0, BTreeMap::new()));
-
-pub fn get_realm(id: usize) -> Option<RealmMutex> {
-    RMS.lock().1.get(&id).map(Arc::clone)
-}
+pub static VMID_SET: Spinlock<BTreeSet<usize>> = Spinlock::new(BTreeSet::new());

--- a/rmm/src/realm/registry.rs
+++ b/rmm/src/realm/registry.rs
@@ -1,13 +1,11 @@
 use crate::realm::Realm;
 
-use crate::realm::context::Context;
-
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
 use spin::mutex::Mutex;
 use spinning_top::Spinlock;
 
-type RealmMutex = Arc<Mutex<Realm<Context>>>;
+type RealmMutex = Arc<Mutex<Realm>>;
 type RealmMap = BTreeMap<usize, RealmMutex>;
 pub static RMS: Spinlock<(usize, RealmMap)> = Spinlock::new((0, BTreeMap::new()));
 

--- a/rmm/src/realm/timer.rs
+++ b/rmm/src/realm/timer.rs
@@ -1,7 +1,7 @@
-use crate::realm::registry::get_realm;
 use crate::realm::vcpu::VCPU;
 use crate::rmi::error::Error;
 use crate::rmi::error::InternalError::*;
+use crate::rmi::realm::Rd;
 use crate::rmi::rec::run::Run;
 
 use armv9a::regs::*;
@@ -40,10 +40,8 @@ pub fn save_state(vcpu: &mut VCPU) {
     timer.cnthctl_el2 = unsafe { S3_4_C14_C1_0.get() };
 }
 
-pub fn send_state_to_host(id: usize, vcpu: usize, run: &mut Run) -> Result<(), Error> {
-    let realm = get_realm(id).ok_or(Error::RmiErrorOthers(NotExistRealm))?;
-    let mut locked_realm = realm.lock();
-    let vcpu = locked_realm
+pub fn send_state_to_host(rd: &mut Rd, vcpu: usize, run: &mut Run) -> Result<(), Error> {
+    let vcpu = rd
         .vcpus
         .get_mut(vcpu)
         .ok_or(Error::RmiErrorOthers(NotExistVCPU))?;

--- a/rmm/src/realm/timer.rs
+++ b/rmm/src/realm/timer.rs
@@ -1,4 +1,3 @@
-use super::context::Context;
 use crate::realm::registry::get_realm;
 use crate::realm::vcpu::VCPU;
 use crate::rmi::error::Error;
@@ -7,17 +6,17 @@ use crate::rmi::rec::run::Run;
 
 use armv9a::regs::*;
 
-pub fn init_timer(vcpu: &mut VCPU<Context>) {
+pub fn init_timer(vcpu: &mut VCPU) {
     let timer = &mut vcpu.context.timer;
     timer.cnthctl_el2 = S3_4_C14_C1_0::EL1PCTEN | S3_4_C14_C1_0::EL1PTEN;
 }
 
-pub fn set_cnthctl(vcpu: &mut VCPU<Context>, val: u64) {
+pub fn set_cnthctl(vcpu: &mut VCPU, val: u64) {
     let timer = &mut vcpu.context.timer;
     timer.cnthctl_el2 = val;
 }
 
-pub fn restore_state(vcpu: &VCPU<Context>) {
+pub fn restore_state(vcpu: &VCPU) {
     let timer = &vcpu.context.timer;
 
     unsafe { CNTVOFF_EL2.set(timer.cntvoff_el2) };
@@ -29,7 +28,7 @@ pub fn restore_state(vcpu: &VCPU<Context>) {
     unsafe { S3_4_C14_C1_0.set(timer.cnthctl_el2) }; // CNTHCTL_EL2
 }
 
-pub fn save_state(vcpu: &mut VCPU<Context>) {
+pub fn save_state(vcpu: &mut VCPU) {
     let timer = &mut vcpu.context.timer;
 
     timer.cntvoff_el2 = unsafe { CNTVOFF_EL2.get() };

--- a/rmm/src/realm/vcpu.rs
+++ b/rmm/src/realm/vcpu.rs
@@ -5,6 +5,7 @@ use crate::realm::registry::get_realm;
 use crate::realm::registry::RMS;
 use crate::realm::timer;
 use crate::rmi::error::Error;
+use crate::rmi::realm::Rd;
 use alloc::sync::{Arc, Weak};
 use armv9a::bits_in_reg;
 use armv9a::regs::*;
@@ -94,10 +95,10 @@ pub unsafe fn current() -> Option<&'static mut VCPU<crate::realm::context::Conte
     }
 }
 
-pub fn create_vcpu(id: usize) -> Result<usize, Error> {
+pub fn create_vcpu(id: usize, rd: &Rd) -> Result<usize, Error> {
     let realm = get_realm(id).ok_or(Error::RmiErrorInput)?;
 
-    let page_table = realm.lock().page_table.lock().get_base_address();
+    let page_table = rd.s2_table().lock().get_base_address();
     let vttbr =
         bits_in_reg(VTTBR_EL2::VMID, id as u64) | bits_in_reg(VTTBR_EL2::BADDR, page_table as u64);
 

--- a/rmm/src/realm/vcpu.rs
+++ b/rmm/src/realm/vcpu.rs
@@ -82,7 +82,7 @@ pub unsafe fn current() -> Option<&'static mut VCPU> {
     }
 }
 
-pub fn create_vcpu(id: usize, rd: &Rd) -> Result<usize, Error> {
+pub fn create_vcpu(id: usize, rd: &mut Rd) -> Result<usize, Error> {
     let realm = get_realm(id).ok_or(Error::RmiErrorInput)?;
 
     let page_table = rd.s2_table().lock().get_base_address();
@@ -94,8 +94,8 @@ pub fn create_vcpu(id: usize, rd: &Rd) -> Result<usize, Error> {
     timer::init_timer(&mut vcpu.lock());
     gic::init_gic(&mut vcpu.lock());
 
-    realm.lock().vcpus.push(vcpu);
-    let vcpuid = realm.lock().vcpus.len() - 1;
+    rd.vcpus.push(vcpu);
+    let vcpuid = rd.vcpus.len() - 1;
     Ok(vcpuid)
 }
 

--- a/rmm/src/rmi/realm/rd.rs
+++ b/rmm/src/rmi/realm/rd.rs
@@ -4,8 +4,10 @@ use vmsa::guard::Content;
 
 use crate::measurement::{Measurement, MEASUREMENTS_SLOT_NR};
 use crate::realm::mm::IPATranslation;
+use crate::realm::vcpu::VCPU;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use spin::mutex::Mutex;
 
 // TODO: Integrate with our `struct Realm`
@@ -20,6 +22,7 @@ pub struct Rd {
     s2_table: Arc<Mutex<Box<dyn IPATranslation>>>,
     hash_algo: u8,
     pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
+    pub vcpus: Vec<Arc<Mutex<VCPU>>>,
 }
 
 impl Rd {
@@ -40,6 +43,7 @@ impl Rd {
         // XXX: without `clone()`, the below assignment would cause a data abort exception
         self.s2_table = s2_table.clone();
         self.measurements = [Measurement::empty(); MEASUREMENTS_SLOT_NR];
+        self.vcpus = Vec::new();
     }
 
     pub fn id(&self) -> usize {

--- a/rmm/src/rmi/realm/rd.rs
+++ b/rmm/src/rmi/realm/rd.rs
@@ -2,6 +2,7 @@ use crate::rmi::rtt::realm_par_size;
 
 use vmsa::guard::Content;
 
+use crate::measurement::{Measurement, MEASUREMENTS_SLOT_NR};
 use crate::realm::mm::IPATranslation;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -18,6 +19,7 @@ pub struct Rd {
     s2_starting_level: isize,
     s2_table: Arc<Mutex<Box<dyn IPATranslation>>>,
     hash_algo: u8,
+    pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
 }
 
 impl Rd {
@@ -37,6 +39,7 @@ impl Rd {
         self.s2_starting_level = s2_starting_level;
         // XXX: without `clone()`, the below assignment would cause a data abort exception
         self.s2_table = s2_table.clone();
+        self.measurements = [Measurement::empty(); MEASUREMENTS_SLOT_NR];
     }
 
     pub fn id(&self) -> usize {

--- a/rmm/src/rmi/realm/rd.rs
+++ b/rmm/src/rmi/realm/rd.rs
@@ -10,10 +10,9 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use spin::mutex::Mutex;
 
-// TODO: Integrate with our `struct Realm`
 #[derive(Debug)]
 pub struct Rd {
-    realm_id: usize,
+    vmid: u16,
     state: State,
     rtt_base: usize,
     ipa_bits: usize,
@@ -28,13 +27,13 @@ pub struct Rd {
 impl Rd {
     pub fn init(
         &mut self,
-        id: usize,
+        vmid: u16,
         rtt_base: usize,
         ipa_bits: usize,
         s2_starting_level: isize,
         s2_table: Arc<Mutex<Box<dyn IPATranslation>>>,
     ) {
-        self.realm_id = id;
+        self.vmid = vmid;
         self.state = State::New;
         self.rtt_base = rtt_base;
         self.ipa_bits = ipa_bits;
@@ -47,7 +46,7 @@ impl Rd {
     }
 
     pub fn id(&self) -> usize {
-        self.realm_id
+        self.vmid as usize
     }
 
     pub fn s2_table(&self) -> &Arc<Mutex<Box<dyn IPATranslation>>> {

--- a/rmm/src/rmi/rec/exit.rs
+++ b/rmm/src/rmi/rec/exit.rs
@@ -1,5 +1,8 @@
 use crate::event::realmexit::*;
 use crate::event::{Context, RsiHandle};
+use crate::get_granule;
+use crate::get_granule_if;
+use crate::granule::GranuleState;
 use crate::granule::GRANULE_MASK;
 use crate::realm::context::get_reg;
 use crate::realm::mm::stage2_tte::S2TTE;
@@ -8,6 +11,7 @@ use crate::rmi::rec::run::Run;
 use crate::rmi::rec::Rec;
 use crate::rmi::rtt::is_protected_ipa;
 use crate::rmi::rtt::RTT_PAGE_LEVEL;
+use crate::rmi::Rd;
 use crate::Monitor;
 use crate::{rmi, rsi};
 use armv9a::{EsrEl2, EMULATABLE_ABORT_MASK, HPFAR_EL2, NON_EMULATABLE_ABORT_MASK};
@@ -67,12 +71,12 @@ pub fn handle_realm_exit(
 }
 
 fn is_non_emulatable_data_abort(
-    realm_id: usize,
+    rd: &Rd,
     ipa_bits: usize,
     fault_ipa: usize,
     esr_el2: u64,
 ) -> Result<bool, Error> {
-    let (s2tte, _) = S2TTE::get_s2tte(realm_id, fault_ipa, RTT_PAGE_LEVEL, Error::RmiErrorRtt(0))?;
+    let (s2tte, _) = S2TTE::get_s2tte(rd, fault_ipa, RTT_PAGE_LEVEL, Error::RmiErrorRtt(0))?;
     let is_protected_ipa = is_protected_ipa(fault_ipa, ipa_bits);
 
     let ret = match is_protected_ipa {
@@ -100,6 +104,8 @@ fn handle_data_abort(
 ) -> Result<usize, Error> {
     let realm_id = rec.realmid()?;
     let ipa_bits = rec.ipa_bits()?;
+    let rd_granule = get_granule_if!(rec.owner()?, GranuleState::RD)?;
+    let rd = rd_granule.content::<Rd>();
 
     let esr_el2 = realm_exit_res[1] as u64;
     let hpfar_el2 = realm_exit_res[2] as u64;
@@ -110,20 +116,20 @@ fn handle_data_abort(
 
     let fault_ipa = ((HPFAR_EL2::FIPA & hpfar_el2) << 8) as usize;
 
-    let (exit_esr, exit_far) =
-        match is_non_emulatable_data_abort(realm_id, ipa_bits, fault_ipa, esr_el2)? {
-            true => (esr_el2 & NON_EMULATABLE_ABORT_MASK, 0),
-            false => {
-                if esr_el2 & EsrEl2::WNR != 0 {
-                    let write_val = get_write_val(realm_id, rec.vcpuid(), esr_el2)?;
-                    run.set_gpr(0, write_val)?;
-                }
-                (
-                    esr_el2 & EMULATABLE_ABORT_MASK,
-                    (far_el2 & !(GRANULE_MASK as u64)),
-                )
+    let (exit_esr, exit_far) = match is_non_emulatable_data_abort(rd, ipa_bits, fault_ipa, esr_el2)?
+    {
+        true => (esr_el2 & NON_EMULATABLE_ABORT_MASK, 0),
+        false => {
+            if esr_el2 & EsrEl2::WNR != 0 {
+                let write_val = get_write_val(realm_id, rec.vcpuid(), esr_el2)?;
+                run.set_gpr(0, write_val)?;
             }
-        };
+            (
+                esr_el2 & EMULATABLE_ABORT_MASK,
+                (far_el2 & !(GRANULE_MASK as u64)),
+            )
+        }
+    };
 
     run.set_esr(exit_esr);
     run.set_far(exit_far);

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -52,7 +52,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         rmm.page_table.map(rec, true);
         let rec = rec_granule.content_mut::<Rec<'_>>();
 
-        match create_vcpu(rd.id()) {
+        match create_vcpu(rd.id(), rd) {
             Ok(vcpuid) => {
                 ret[1] = vcpuid;
                 rec.init(owner, vcpuid, params.flags)?;

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -52,7 +52,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         rmm.page_table.map(rec, true);
         let rec = rec_granule.content_mut::<Rec<'_>>();
 
-        match create_vcpu(rd.id(), rd) {
+        match create_vcpu(rd) {
             Ok(vcpuid) => {
                 ret[1] = vcpuid;
                 rec.init(owner, vcpuid, params.flags)?;

--- a/rmm/src/rmi/rec/mod.rs
+++ b/rmm/src/rmi/rec/mod.rs
@@ -184,7 +184,7 @@ fn enter() -> [usize; 4] {
             if vcpu.is_realm_dead() {
                 vcpu.from_current();
             } else {
-                vcpu.realm.lock().page_table.lock().clean();
+                // TODO: add code equivalent to the previous clean()
                 return rmm_exit([0; 4]);
             }
         }

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -86,8 +86,8 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     });
 
     listen!(mainloop, rmi::RTT_INIT_RIPAS, |arg, _ret, _rmm| {
-        let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
-        let rd = rd_granule.content::<Rd>();
+        let mut rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
+        let rd = rd_granule.content_mut::<Rd>();
         let ipa = arg[1];
         let level = arg[2];
 
@@ -176,8 +176,8 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         }
 
         // rd granule lock
-        let rd_granule = get_granule_if!(rd, GranuleState::RD)?;
-        let rd = rd_granule.content::<Rd>();
+        let mut rd_granule = get_granule_if!(rd, GranuleState::RD)?;
+        let rd = rd_granule.content_mut::<Rd>();
 
         // Make sure DATA_CREATE is only processed
         // when the realm is in its New state.

--- a/rmm/src/rsi/measurement.rs
+++ b/rmm/src/rsi/measurement.rs
@@ -1,19 +1,15 @@
 use crate::measurement::MeasurementError;
-use crate::realm::registry::get_realm;
 use crate::rsi::error::Error;
+use crate::rsi::Rd;
 
 pub fn read(
-    realmid: usize,
+    rd: &Rd,
     index: usize,
     out: &mut crate::measurement::Measurement,
 ) -> Result<(), crate::rsi::error::Error> {
-    let realm_lock = get_realm(realmid).ok_or(Error::RealmDoesNotExists)?;
-
-    let mut realm = realm_lock.lock();
-
-    let measurement = realm
+    let measurement = rd
         .measurements
-        .iter_mut()
+        .iter()
         .nth(index)
         .ok_or(Error::InvalidMeasurementIndex)?;
 
@@ -22,15 +18,11 @@ pub fn read(
 }
 
 pub fn extend(
-    realmid: usize,
+    rd: &mut Rd,
     index: usize,
     f: impl Fn(&mut crate::measurement::Measurement) -> Result<(), MeasurementError>,
 ) -> Result<(), crate::rsi::error::Error> {
-    let realm_lock = get_realm(realmid).ok_or(Error::RealmDoesNotExists)?;
-
-    let mut realm = realm_lock.lock();
-
-    let measurement = realm
+    let measurement = rd
         .measurements
         .iter_mut()
         .nth(index)

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -76,8 +76,10 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         |_arg: &[usize], ret: &mut [usize], _rmm: &Monitor, rec: &mut Rec<'_>, _run: &mut Run| {
             let vcpuid = rec.vcpuid();
             let realmid = rec.realmid()?;
+            let rd_granule = get_granule_if!(rec.owner()?, GranuleState::RD)?;
+            let rd = rd_granule.content::<Rd>();
 
-            if set_reg(realmid, vcpuid, 0, PsciReturn::SUCCESS).is_err() {
+            if set_reg(rd, vcpuid, 0, PsciReturn::SUCCESS).is_err() {
                 warn!(
                     "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                     realmid, vcpuid
@@ -90,8 +92,10 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, PSCI_VERSION, |_arg, ret, _rmm, rec, _run| {
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
+        let rd_granule = get_granule_if!(rec.owner()?, GranuleState::RD)?;
+        let rd = rd_granule.content::<Rd>();
 
-        if set_reg(realmid, vcpuid, 0, psci_version()).is_err() {
+        if set_reg(rd, vcpuid, 0, psci_version()).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                 realmid, vcpuid
@@ -121,8 +125,10 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, SMC32::FEATURES, |_arg, ret, _rmm, rec, _run| {
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
+        let rd_granule = get_granule_if!(rec.owner()?, GranuleState::RD)?;
+        let rd = rd_granule.content::<Rd>();
 
-        let feature_id = get_reg(realmid, vcpuid, 1).unwrap_or(0x0);
+        let feature_id = get_reg(rd, vcpuid, 1).unwrap_or(0x0);
         let retval = match feature_id {
             SMC32::CPU_SUSPEND
             | SMC64::CPU_SUSPEND
@@ -137,7 +143,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
             | SMCCC_VERSION => PsciReturn::SUCCESS,
             _ => PsciReturn::NOT_SUPPORTED,
         };
-        if set_reg(realmid, vcpuid, 0, retval).is_err() {
+        if set_reg(rd, vcpuid, 0, retval).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                 realmid, vcpuid
@@ -150,8 +156,10 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, SMCCC_VERSION, |_arg, ret, _rmm, rec, _run| {
         let vcpuid = rec.vcpuid();
         let realmid = rec.realmid()?;
+        let rd_granule = get_granule_if!(rec.owner()?, GranuleState::RD)?;
+        let rd = rd_granule.content::<Rd>();
 
-        if set_reg(realmid, vcpuid, 0, smccc_version()).is_err() {
+        if set_reg(rd, vcpuid, 0, smccc_version()).is_err() {
             warn!(
                 "Unable to set register 0. realmid: {:?} vcpuid: {:?}",
                 realmid, vcpuid


### PR DESCRIPTION
This PR contains the refactoring commits related to the earlier discussion (#230). Realm and Rd (Realm Descriptor) have almost the same purpose. It aims to keep only Rd which is defined by spec.

## Summary of changes
```
-pub struct Realm {
-   id: usize,
-   pub vmid: u16,
-   pub state: State,
-   pub vcpus: Vec<Arc<Mutex<VCPU>>>,
-   pub page_table: Arc<Mutex<Box<dyn IPATranslation>>>,
-   pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
-}

pub struct Rd {
-   realm_id: usize,
+   vmid: u16,
    ...
+   s2_table: Arc<Mutex<Box<dyn IPATranslation>>>,
    hash_algo: u8,
+   pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
+   pub vcpus: Vec<Arc<Mutex<VCPU>>>,
}
```
## Notes
- `vmid` is integrated with `id` so that only `vmid`, passed by the Host, is used
- `VMID_SET` is used instead of the previous `RMS` (Realm Map Struct?)
- `trait Context` and redundant `enum State` have been removed

## Changes in the caller side
```
[before]
   let (s2tte, last_level) = get_realm(realm_id)
          .ok_or(Error::RmiErrorOthers(NotExistRealm))?
          .lock()
          .page_table
          .lock()
          .ipa_to_pte(GuestPhysAddr::from(ipa), level)
          .ok_or(error_code)?;

[after]
   let (s2tte, last_level) = rd
          .s2_table()
          .lock()
          .ipa_to_pte(GuestPhysAddr::from(ipa), level)
          .ok_or(error_code)?;
```

```
[before]
   let measurements = crate::realm::registry::get_realm(realmid)
        .ok_or(Error::RmiErrorOthers(NotExistRealm))?
        .lock()
        .measurements;

[after]
   let measurements = rd.measurements;
```

## A caution
- Two data aborts are newly generated during realm creation for some reasons which will be analyzed and fixed later