### PR TITLE
ci: Add certifier compatibility test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,9 @@ jobs:
       working-directory: sdk
       run: make sdk
 
+    - name: Test Certifier compatibility
+      run: ./scripts/tests/certifier-compatibility.sh
+
   cli:
     runs-on: ubuntu-22.04
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,7 @@
 	branch = 3rd-kvmtool-rim-measurer
 [submodule "third-party/certifier"]
 	path = third-party/certifier
-	url = https://github.com/vmware-research/certifier-framework-for-confidential-computing
+	url = https://github.com/ccc-certifier-framework/certifier-framework-for-confidential-computing
 [submodule "third-party/cargo-geiger"]
 	path = third-party/cargo-geiger
 	url = https://github.com/bitboom/cargo-geiger

--- a/scripts/tests/certifier-compatibility.sh
+++ b/scripts/tests/certifier-compatibility.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+ROOT=$(git rev-parse --show-toplevel)
+CERTIFIER=$ROOT/third-party/certifier
+
+apt-get update && apt -y install sudo
+
+sudo apt-get update
+
+sudo apt-get install -y -qq --no-install-recommends --fix-missing \
+	clang-format-11 libgtest-dev libgflags-dev \
+	openssl libssl-dev protobuf-compiler protoc-gen-go golang-go cmake
+
+git submodule update --init --depth 1 $CERTIFIER
+
+cd $CERTIFIER
+./CI/scripts/test.sh test-ISLET-SDK-shim_test
+./CI/scripts/test.sh test-run_example-simple_app_under_islet-using-shim


### PR DESCRIPTION
This PR enables the `Certifier` job.

- Checks whether the latest `Islet SDK` and `Certifier` are compatible.
- Cross-test related with this PR: https://github.com/ccc-certifier-framework/certifier-framework-for-confidential-computing/pull/245