### PR TITLE
Apply `--deny warnings` to clippy

### DIFF
--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -103,7 +103,7 @@ impl Context {
 
         let ret_len = self.ret.len();
         result[..ret_len].copy_from_slice(&self.ret[..]);
-        return result;
+        result
     }
 
     pub fn do_rsi<F>(&mut self, mut handler: F)

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -16,4 +16,5 @@ cargo clippy --lib -p islet_rmm -- \
 	-A clippy::new_without_default \
 	-A clippy::redundant_pattern_matching \
 	-A clippy::type_complexity \
-	-A clippy::identity_op
+	-A clippy::identity_op \
+	--deny "warnings"


### PR DESCRIPTION
Minor fix for denying warnings