### PR TITLE
Add harnesses for verifying rmi granule delegate and undelegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ machine-to-machine computing without the need for server intervention
 - Realm Management Monitor
 - Hardware Enforced Security
 - Confidential Computing API Standardization
+- Automated Verification
 - Use case : Confidential Machine Learning
 
 ## Overall Architecture

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -7,6 +7,7 @@
   - [Application Developer](./getting-started/app-dev.md)
   - [Platform Developer](./getting-started/plat-dev.md)
     - [Network Configuration](./network.md)
+  - [Verification](./getting-started/verification.md)
 - [Components](./components/index.md)
   - [CCA platform architecture](./components/cca_design.md)
   - [Realm Management Monitor](./components/rmm.md)

--- a/doc/getting-started/index.md
+++ b/doc/getting-started/index.md
@@ -2,3 +2,4 @@
 - [1.1. About CCA](https://islet-project.github.io/islet/getting-started/cca.html)
 - [1.2. Application Developer](https://islet-project.github.io/islet/getting-started/app-dev.html)
 - [1.3. Platform Developer](https://islet-project.github.io/islet/getting-started/plat-dev.html)
+- [1.4. Verification](https://islet-project.github.io/islet/getting-started/verification.html)

--- a/doc/getting-started/verification.md
+++ b/doc/getting-started/verification.md
@@ -1,0 +1,27 @@
+# Verification
+
+We formally verify Islet using [Kani](https://github.com/model-checking/kani/)'s model
+checking. Our verification harnesses adopt the same input and output conditions as well
+as similar structures used in [TF-RMM](https://www.trustedfirmware.org/projects/tf-rmm/)'s
+harnesses which are extracted from Machine Readable Specification. It would help to check
+the conformance of the two systems written in different languages.
+
+## Verification dependency
+* [patched Kani](https://github.com/zpzigi754/kani/tree/use-aarch64-latest)
+
+## Available RMI targets
+
+```sh
+rmi_features
+rmi_granule_delegate
+rmi_granule_undelegate
+```
+
+## Verifying Islet
+
+```sh
+(in islet/model-checking)
+
+# Choose one among the list in `Available RMI targets` for the value of `RMI_TARGET`
+$ RMI_TARGET=rmi_granule_undelegate make verify
+```

--- a/model-checking/Cargo.toml
+++ b/model-checking/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # The below are features relevant for model checking
 mc_rmi_features = ["islet_rmm/mc_rmi_features"]
 mc_rmi_granule_delegate = ["islet_rmm/mc_rmi_granule_delegate"]
+mc_rmi_granule_undelegate = ["islet_rmm/mc_rmi_granule_undelegate"]
 
 [dependencies]
 islet_rmm = { path = "../rmm" }

--- a/model-checking/Cargo.toml
+++ b/model-checking/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [features]
 # The below are features relevant for model checking
 mc_rmi_features = ["islet_rmm/mc_rmi_features"]
+mc_rmi_granule_delegate = ["islet_rmm/mc_rmi_granule_delegate"]
 
 [dependencies]
 islet_rmm = { path = "../rmm" }

--- a/model-checking/Makefile
+++ b/model-checking/Makefile
@@ -10,7 +10,8 @@ KANI_FLAGS := \
 RMI_TARGET ?= rmi_features
 ALLOWED_RMI_TARGET = \
 	rmi_features \
-	rmi_granule_delegate
+	rmi_granule_delegate \
+	rmi_granule_undelegate
 
 ifeq ("$(filter $(RMI_TARGET), $(ALLOWED_RMI_TARGET))", "")
     $(error Invalid RMI_TARGET. Choose one of the following: $(ALLOWED_RMI_TARGET))

--- a/model-checking/Makefile
+++ b/model-checking/Makefile
@@ -1,7 +1,11 @@
+MODEL_CHECKING_DIR := $(CURDIR)/src
+
 KANI_FLAGS := \
 	--enable-unstable \
 	--ignore-global-asm \
-	--restrict-vtable
+	--restrict-vtable \
+	--c-lib $(MODEL_CHECKING_DIR)/stub.c \
+	-Z c-ffi
 
 RMI_TARGET ?= rmi_features
 ALLOWED_RMI_TARGET = \

--- a/model-checking/Makefile
+++ b/model-checking/Makefile
@@ -9,7 +9,8 @@ KANI_FLAGS := \
 
 RMI_TARGET ?= rmi_features
 ALLOWED_RMI_TARGET = \
-	rmi_features
+	rmi_features \
+	rmi_granule_delegate
 
 ifeq ("$(filter $(RMI_TARGET), $(ALLOWED_RMI_TARGET))", "")
     $(error Invalid RMI_TARGET. Choose one of the following: $(ALLOWED_RMI_TARGET))

--- a/model-checking/src/common.rs
+++ b/model-checking/src/common.rs
@@ -1,0 +1,74 @@
+use islet_rmm::granule::array::GRANULE_SIZE;
+use islet_rmm::granule::entry::GranuleGpt;
+
+#[macro_export]
+// DIFF: `islet_rmm` is used to find the names outside the `islet_rmm` crate
+//       [before]
+//       use crate::granule::array::{GRANULE_STATUS_TABLE, GRANULE_STATUS_TABLE_SIZE};
+//       [after]
+//       use islet_rmm::granule::array::{GRANULE_STATUS_TABLE, GRANULE_STATUS_TABLE_SIZE};
+macro_rules! get_granule {
+    ($addr:expr) => {{
+        use islet_rmm::granule::array::{GRANULE_STATUS_TABLE, GRANULE_STATUS_TABLE_SIZE};
+        use islet_rmm::granule::{granule_addr_to_index, validate_addr};
+        use islet_rmm::rmi::error::Error;
+        if !validate_addr($addr) {
+            Err(Error::RmiErrorInput)
+        } else {
+            let idx = granule_addr_to_index($addr);
+            if idx >= GRANULE_STATUS_TABLE_SIZE {
+                Err(Error::RmiErrorInput)
+            } else {
+                let gst = &GRANULE_STATUS_TABLE;
+                match gst.entries[idx].lock() {
+                    Ok(guard) => Ok(guard),
+                    Err(e) => Err(e),
+                }
+            }
+        }
+    }};
+}
+
+pub fn addr_is_granule_aligned(addr: usize) -> bool {
+    addr % GRANULE_SIZE == 0
+}
+
+// This should be exclusively used by pre-condition
+// to retrieve a granule's state value.
+// `unwrap()` is not called to avoid a panic condition.
+pub fn pre_granule_state(addr: usize) -> u8 {
+    let gran_state_res = get_granule!(addr).map(|guard| guard.state());
+    let gran_state = if let Ok(state) = gran_state_res {
+        state
+    } else {
+        kani::any()
+    };
+    gran_state
+}
+
+// This should be exclusively used by post-condition
+// to retrieve a granule's state value.
+// `unwrap()` is guaranteed not to be reached.
+pub fn post_granule_state(addr: usize) -> u8 {
+    get_granule!(addr).map(|guard| guard.state()).unwrap()
+}
+
+// This should be exclusively used by pre-condition
+// to retrieve a granule's gpt value.
+// `unwrap()` is not called to avoid a panic condition.
+pub fn pre_granule_gpt(addr: usize) -> GranuleGpt {
+    let gran_gpt_res = get_granule!(addr).map(|guard| guard.gpt);
+    let gran_gpt = if let Ok(gpt) = gran_gpt_res {
+        gpt
+    } else {
+        kani::any()
+    };
+    gran_gpt
+}
+
+// This should be exclusively used by post-condition
+// to retrieve a granule's gpt value.
+// `unwrap()` is guaranteed not to be reached.
+pub fn post_granule_gpt(addr: usize) -> GranuleGpt {
+    get_granule!(addr).map(|guard| guard.gpt).unwrap()
+}

--- a/model-checking/src/common.rs
+++ b/model-checking/src/common.rs
@@ -1,5 +1,9 @@
-use islet_rmm::granule::array::GRANULE_SIZE;
+use islet_rmm::granule::array::{GRANULE_REGION, GRANULE_SIZE};
 use islet_rmm::granule::entry::GranuleGpt;
+
+extern "C" {
+    fn CPROVER_havoc_object(address: usize);
+}
 
 #[macro_export]
 // DIFF: `islet_rmm` is used to find the names outside the `islet_rmm` crate
@@ -71,4 +75,10 @@ pub fn pre_granule_gpt(addr: usize) -> GranuleGpt {
 // `unwrap()` is guaranteed not to be reached.
 pub fn post_granule_gpt(addr: usize) -> GranuleGpt {
     get_granule!(addr).map(|guard| guard.gpt).unwrap()
+}
+
+pub fn initialize() {
+    unsafe {
+        CPROVER_havoc_object(GRANULE_REGION.as_ptr() as usize);
+    }
 }

--- a/model-checking/src/lib.rs
+++ b/model-checking/src/lib.rs
@@ -1,3 +1,5 @@
 mod common;
 #[cfg(feature = "mc_rmi_features")]
 mod rmi_features;
+#[cfg(feature = "mc_rmi_granule_delegate")]
+mod rmi_granule_delegate;

--- a/model-checking/src/lib.rs
+++ b/model-checking/src/lib.rs
@@ -3,3 +3,5 @@ mod common;
 mod rmi_features;
 #[cfg(feature = "mc_rmi_granule_delegate")]
 mod rmi_granule_delegate;
+#[cfg(feature = "mc_rmi_granule_undelegate")]
+mod rmi_granule_undelegate;

--- a/model-checking/src/lib.rs
+++ b/model-checking/src/lib.rs
@@ -1,2 +1,3 @@
+mod common;
 #[cfg(feature = "mc_rmi_features")]
 mod rmi_features;

--- a/model-checking/src/rmi_granule_delegate.rs
+++ b/model-checking/src/rmi_granule_delegate.rs
@@ -1,0 +1,119 @@
+use crate::common::addr_is_granule_aligned;
+use crate::common::{post_granule_gpt, post_granule_state, pre_granule_gpt, pre_granule_state};
+use crate::get_granule;
+use islet_rmm::granule::entry::GranuleGpt;
+use islet_rmm::granule::validate_addr;
+use islet_rmm::granule::GranuleState;
+use islet_rmm::monitor::Monitor;
+use islet_rmm::rmi;
+use islet_rmm::rmi::error::Error;
+
+#[kani::proof]
+#[kani::unwind(9)]
+fn verify_granule_delegate() {
+    // Initialize registers (symbolic input)
+    let regs: [usize; 8] = kani::any();
+    kani::assume(regs[0] == rmi::GRANULE_DELEGATE);
+    // TODO: check the below again
+    let addr = regs[1];
+
+    // Pre-conditions
+    let failure_gran_align_pre = !addr_is_granule_aligned(addr);
+    let failure_gran_bound_pre = !validate_addr(addr);
+    let failure_gran_state_pre = pre_granule_state(addr) != GranuleState::Undelegated;
+    let failure_gran_gpt_pre = pre_granule_gpt(addr) != GranuleGpt::GPT_NS;
+    let no_failures_pre = !failure_gran_align_pre
+        && !failure_gran_bound_pre
+        && !failure_gran_state_pre
+        && !failure_gran_gpt_pre;
+
+    // Execute command and read the result.
+    let out = Monitor::new().run(regs);
+    let result = out[0];
+
+    // Post conditions have been moved to be inside if statements
+    // to constrain the conditions in order not to touch the panic in unwrap();
+
+    // Failure condition assertions
+    let prop_failure_gran_align_ante = failure_gran_align_pre;
+
+    kani::cover!();
+    if prop_failure_gran_align_ante {
+        let failure_gran_align_post = result == Error::RmiErrorInput.into();
+        let prop_failure_gran_align_cons = failure_gran_align_post;
+
+        kani::cover!();
+        assert!(prop_failure_gran_align_cons);
+    }
+
+    let prop_failure_gran_bound_ante = !failure_gran_align_pre && failure_gran_bound_pre;
+
+    kani::cover!();
+    if prop_failure_gran_bound_ante {
+        let failure_gran_bound_post = result == Error::RmiErrorInput.into();
+        let prop_failure_gran_bound_cons = failure_gran_bound_post;
+
+        kani::cover!();
+        assert!(prop_failure_gran_bound_cons);
+    }
+
+    let prop_failure_gran_state_ante =
+        !failure_gran_align_pre && !failure_gran_bound_pre && failure_gran_state_pre;
+
+    kani::cover!();
+    if prop_failure_gran_state_ante {
+        let failure_gran_state_post = result == Error::RmiErrorInput.into();
+        let prop_failure_gran_state_cons = failure_gran_state_post;
+
+        kani::cover!();
+        assert!(prop_failure_gran_state_cons);
+    }
+
+    let prop_failure_gran_gpt_ante = !failure_gran_align_pre
+        && !failure_gran_bound_pre
+        && !failure_gran_state_pre
+        && failure_gran_gpt_pre;
+
+    kani::cover!();
+    if prop_failure_gran_gpt_ante {
+        let failure_gran_gpt_post = result == Error::RmiErrorInput.into();
+        let prop_failure_gran_gpt_cons = failure_gran_gpt_post;
+
+        kani::cover!();
+        assert!(prop_failure_gran_gpt_cons);
+    }
+
+    // Result assertion
+    let prop_result_ante = no_failures_pre;
+
+    kani::cover!();
+    if prop_result_ante {
+        let prop_result_cons = result == rmi::SUCCESS;
+
+        kani::cover!();
+        assert!(prop_result_cons);
+    }
+
+    // Success condition assertions
+    let prop_success_gran_state_ante = no_failures_pre;
+
+    kani::cover!();
+    if prop_success_gran_state_ante {
+        let success_gran_state_post = post_granule_state(addr) == GranuleState::Delegated;
+        let prop_success_gran_state_cons = success_gran_state_post && (result == rmi::SUCCESS);
+
+        kani::cover!();
+        assert!(prop_success_gran_state_cons);
+    }
+
+    let prop_success_gran_gpt_ante = no_failures_pre;
+
+    kani::cover!();
+    if prop_success_gran_gpt_ante {
+        let success_gran_gpt_post = post_granule_gpt(addr) == GranuleGpt::GPT_REALM;
+        let prop_success_gran_gpt_cons = success_gran_gpt_post && (result == rmi::SUCCESS);
+
+        kani::cover!();
+        assert!(prop_success_gran_gpt_cons);
+    }
+}

--- a/model-checking/src/rmi_granule_undelegate.rs
+++ b/model-checking/src/rmi_granule_undelegate.rs
@@ -1,0 +1,121 @@
+use crate::common::addr_is_granule_aligned;
+use crate::common::initialize;
+use crate::common::{post_granule_gpt, post_granule_state, pre_granule_state};
+use crate::get_granule;
+use islet_rmm::granule::entry::GranuleGpt;
+use islet_rmm::granule::validate_addr;
+use islet_rmm::granule::GranuleState;
+use islet_rmm::monitor::Monitor;
+use islet_rmm::rmi;
+use islet_rmm::rmi::error::Error;
+
+#[kani::proof]
+#[kani::unwind(9)]
+fn verify_granule_undelegate() {
+    initialize();
+
+    // Initialize registers (symbolic input)
+    let regs: [usize; 8] = kani::any();
+    kani::assume(regs[0] == rmi::GRANULE_UNDELEGATE);
+    // TODO: check the below again
+    let addr = regs[1];
+
+    // Pre-conditions
+    let failure_gran_align_pre = !addr_is_granule_aligned(addr);
+    let failure_gran_bound_pre = !validate_addr(addr);
+    let failure_gran_state_pre = pre_granule_state(addr) != GranuleState::Delegated;
+    let no_failures_pre =
+        !failure_gran_align_pre && !failure_gran_bound_pre && !failure_gran_state_pre;
+
+    // Execute command and read the result.
+    let out = Monitor::new().run(regs);
+    let result = out[0];
+
+    // Post conditions have been moved to be inside if statements
+    // to constrain the conditions in order not to touch the panic in unwrap();
+
+    // Failure condition assertions
+    let prop_failure_gran_align_ante = failure_gran_align_pre;
+
+    kani::cover!();
+    if prop_failure_gran_align_ante {
+        let failure_gran_align_post = result == Error::RmiErrorInput.into();
+        let prop_failure_gran_align_cons = failure_gran_align_post;
+
+        kani::cover!();
+        assert!(prop_failure_gran_align_cons);
+    }
+
+    let prop_failure_gran_bound_ante = !failure_gran_align_pre && failure_gran_bound_pre;
+
+    kani::cover!();
+    if prop_failure_gran_bound_ante {
+        let failure_gran_bound_post = result == Error::RmiErrorInput.into();
+        let prop_failure_gran_bound_cons = failure_gran_bound_post;
+
+        kani::cover!();
+        assert!(prop_failure_gran_bound_cons);
+    }
+
+    let prop_failure_gran_state_ante =
+        !failure_gran_align_pre && !failure_gran_bound_pre && failure_gran_state_pre;
+
+    kani::cover!();
+    if prop_failure_gran_state_ante {
+        let failure_gran_state_post = result == Error::RmiErrorInput.into();
+        let prop_failure_gran_state_cons = failure_gran_state_post;
+
+        kani::cover!();
+        assert!(prop_failure_gran_state_cons);
+    }
+
+    // Result assertion
+    let prop_result_ante = no_failures_pre;
+
+    kani::cover!();
+    if prop_result_ante {
+        let prop_result_cons = result == rmi::SUCCESS;
+
+        kani::cover!();
+        assert!(prop_result_cons);
+    }
+
+    // Success condition assertions
+    let prop_success_gran_gpt_ante = no_failures_pre;
+
+    kani::cover!();
+    if prop_success_gran_gpt_ante {
+        let success_gran_gpt_post = post_granule_gpt(addr) == GranuleGpt::GPT_NS;
+        let prop_success_gran_gpt_cons = success_gran_gpt_post && (result == rmi::SUCCESS);
+
+        kani::cover!();
+        assert!(prop_success_gran_gpt_cons);
+    }
+
+    let prop_success_gran_state_ante = no_failures_pre;
+
+    kani::cover!();
+    if prop_success_gran_state_ante {
+        let success_gran_state_post = post_granule_state(addr) == GranuleState::Undelegated;
+        let prop_success_gran_state_cons = success_gran_state_post && (result == rmi::SUCCESS);
+
+        kani::cover!();
+        assert!(prop_success_gran_state_cons);
+    }
+
+    let prop_success_gran_content_ante = no_failures_pre;
+
+    kani::cover!();
+    if prop_success_gran_content_ante {
+        let success_gran_content = get_granule!(addr)
+            .map(|guard| guard.index_to_addr())
+            .unwrap();
+        // check the first byte to reduce the proof overhead
+        let success_gran_content_post = unsafe { *(success_gran_content as *const u8) } == 0;
+
+        let prop_success_gran_content_cons = success_gran_content_post && (result == rmi::SUCCESS);
+
+        kani::cover!();
+        assert!(prop_success_gran_content_cons);
+    }
+}

--- a/model-checking/src/stub.c
+++ b/model-checking/src/stub.c
@@ -1,0 +1,3 @@
+struct Unit CPROVER_havoc_object(unsigned long address) {
+    __CPROVER_havoc_object(address);
+}

--- a/rmm/Cargo.toml
+++ b/rmm/Cargo.toml
@@ -39,3 +39,4 @@ gst_page_table = []
 
 # The below are features relevant for model checking
 mc_rmi_features = []
+mc_rmi_granule_delegate = []

--- a/rmm/Cargo.toml
+++ b/rmm/Cargo.toml
@@ -40,3 +40,4 @@ gst_page_table = []
 # The below are features relevant for model checking
 mc_rmi_features = []
 mc_rmi_granule_delegate = []
+mc_rmi_granule_undelegate = []

--- a/rmm/src/event/mainloop.rs
+++ b/rmm/src/event/mainloop.rs
@@ -39,7 +39,10 @@ impl Mainloop {
     fn add_event_handlers(&mut self) {
         #[cfg(feature = "mc_rmi_features")]
         rmi::features::set_event_handler(self);
-        #[cfg(feature = "mc_rmi_granule_delegate")]
+        #[cfg(any(
+            feature = "mc_rmi_granule_delegate",
+            feature = "mc_rmi_granule_undelegate"
+        ))]
         rmi::gpt::set_event_handler(self);
     }
 

--- a/rmm/src/event/mainloop.rs
+++ b/rmm/src/event/mainloop.rs
@@ -39,6 +39,8 @@ impl Mainloop {
     fn add_event_handlers(&mut self) {
         #[cfg(feature = "mc_rmi_features")]
         rmi::features::set_event_handler(self);
+        #[cfg(feature = "mc_rmi_granule_delegate")]
+        rmi::gpt::set_event_handler(self);
     }
 
     #[cfg(not(kani))]

--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -102,6 +102,12 @@ impl Context {
         self.arg.extend_from_slice(&self.ret[..]);
 
         let ret_len = self.ret.len();
+        #[cfg(kani)]
+        // the below is a proof helper
+        {
+            #[cfg(feature = "mc_rmi_granule_delegate")]
+            assert!(ret_len == 1);
+        }
         result[..ret_len].copy_from_slice(&self.ret[..]);
         result
     }

--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -105,7 +105,10 @@ impl Context {
         #[cfg(kani)]
         // the below is a proof helper
         {
-            #[cfg(feature = "mc_rmi_granule_delegate")]
+            #[cfg(any(
+                feature = "mc_rmi_granule_delegate",
+                feature = "mc_rmi_granule_undelegate"
+            ))]
             assert!(ret_len == 1);
         }
         result[..ret_len].copy_from_slice(&self.ret[..]);

--- a/rmm/src/granule/array/mod.rs
+++ b/rmm/src/granule/array/mod.rs
@@ -89,6 +89,13 @@ impl GranuleStatusTable {
             entries: core::array::from_fn(|_| Entry::new()),
         }
     }
+
+    #[cfg(kani)]
+    pub fn is_valid(&self) -> bool {
+        self.entries
+            .iter()
+            .fold(true, |acc, x| acc && x.lock().unwrap().is_valid())
+    }
 }
 
 #[macro_export]

--- a/rmm/src/granule/array/mod.rs
+++ b/rmm/src/granule/array/mod.rs
@@ -143,14 +143,14 @@ impl GranuleStatusTable {
 #[macro_export]
 macro_rules! get_granule {
     ($addr:expr) => {{
-        use crate::granule::array::GRANULE_STATUS_TABLE;
+        use crate::granule::array::{GRANULE_STATUS_TABLE, GRANULE_STATUS_TABLE_SIZE};
         use crate::granule::{granule_addr_to_index, validate_addr};
         use crate::rmi::error::Error;
         if !validate_addr($addr) {
             Err(Error::RmiErrorInput)
         } else {
             let idx = granule_addr_to_index($addr);
-            if idx == usize::MAX {
+            if idx >= GRANULE_STATUS_TABLE_SIZE {
                 Err(Error::RmiErrorInput)
             } else {
                 let gst = &GRANULE_STATUS_TABLE;

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -48,7 +48,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    #[cfg(not(kani))]
+    #[cfg(any(not(kani), feature = "mc_rmi_granule_undelegate"))]
     listen!(mainloop, rmi::GRANULE_UNDELEGATE, |arg, _, rmm| {
         let addr = arg[0];
         let mut granule = get_granule_if!(addr, GranuleState::Delegated)?;

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -19,6 +19,7 @@ pub const MARK_REALM: usize = 0xc400_01b0;
 pub const MARK_NONSECURE: usize = 0xc400_01b1;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
+    #[cfg(any(not(kani), feature = "mc_rmi_granule_delegate"))]
     listen!(mainloop, rmi::GRANULE_DELEGATE, |arg, _, rmm| {
         let addr = arg[0];
         #[cfg(feature = "gst_page_table")]
@@ -47,6 +48,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
+    #[cfg(not(kani))]
     listen!(mainloop, rmi::GRANULE_UNDELEGATE, |arg, _, rmm| {
         let addr = arg[0];
         let mut granule = get_granule_if!(addr, GranuleState::Delegated)?;

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -15,8 +15,8 @@ use vmsa::error::Error as MmError;
 extern crate alloc;
 
 // defined in trusted-firmware-a/include/services/rmmd_svc.h
-const MARK_REALM: usize = 0xc400_01b0;
-const MARK_NONSECURE: usize = 0xc400_01b1;
+pub const MARK_REALM: usize = 0xc400_01b0;
+pub const MARK_NONSECURE: usize = 0xc400_01b1;
 
 pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::GRANULE_DELEGATE, |arg, _, rmm| {


### PR DESCRIPTION
This PR adds two verification harnesses for model checking: RMI_GRANULE_DELEGATE and RMI_GRANULE_UNDELEGATE.

It found one correctness bug (https://github.com/islet-project/islet/pull/307). 

## How to use?
```
(in islet/model-checking)

$ RMI_TARGET=rmi_granule_(un)delegate make verify 

...
SUMMARY:
 ** 0 of 3055 failed (81 unreachable)

 ** 14 of 14 cover properties satisfied
```

## Summary of changes
- Add a ghost gpt field in granule entry for tracking Granule Protection Table (GPT)'s change
- Add `is_valid` predicate for ensuring Granule Status Table (GST)'s valid status
- Put common helper functions in `common` module (`pre_/post_granule_state()`, `pre_/post_granule_gpt()`, etc)
- Add host memory and EL3 gpt change modeling code to help harnesses interact with their environment

## About host memory modeling
This models the Host memory as a pre-allocated memory region which can avoid a false positive related to invalid memory accesses in model checking. Also, instead of using the same starting address (e.g., 0x8000_0000), it uses a mock region filled with non-deterministic contents. This approach helps to address an issue related to the backend CBMC's pointer encoding, as 0x8000_0000 cannot be distinguished from null pointer in CBMC.

## Invariants with `is_valid()` predicate
The added `is_valid()` predicate can be used to ensure that all granule entries in GST are in valid status conforminig to the spec A2.2.1.

```
A2.2.1 Granule attributes in beta0-eac4

If the state of a Granule is not UNDELEGATED then the PAS of the Granule is REALM.
If the state of a Granule is UNDELEGATED then the PAS of the Granule is not REALM.
```