### PR TITLE
ci: Use depth 1 when syncing assets for speeding up

### DIFF
--- a/scripts/deps/assets.sh
+++ b/scripts/deps/assets.sh
@@ -4,6 +4,6 @@ set -e
 
 ROOT=$(git rev-parse --show-toplevel)
 
-cd $ROOT && git submodule update --init assets
+cd $ROOT && git submodule update --init --depth 1 assets
 git submodule update --init --depth 1 $ROOT/third-party/ciborium
 git submodule update --init --depth 1 $ROOT/third-party/coset


### PR DESCRIPTION
This is a minor PR for speeding up ci tests as well as reducing overall disk consumption. 

```
(in scripts/deps/assets.sh)

[before]
cd $ROOT && git submodule update --init assets

[after]
cd $ROOT && git submodule update --init --depth 1 assets
```