### PR TITLE
scripts: Remove cargo install to avoid a feature error

### DIFF
--- a/scripts/deps/rust.sh
+++ b/scripts/deps/rust.sh
@@ -18,6 +18,4 @@ rustup component add rust-src rustfmt
 rustup target add aarch64-unknown-linux-gnu
 rustup component add clippy
 
-cargo install cargo-bloat cbindgen mdbook
-
 rustc --version --verbose


### PR DESCRIPTION
This fix is intended for resolving the below error in AnalysisHub.

```
$ ./scripts/deps/rust.sh
...
   Compiling tempfile v3.10.1
   Compiling serde_derive v1.0.201
error[E0658]: use of unstable library feature 'saturating_int_impl'
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.201/src/lib.rs:280:13
    |
280 |     pub use self::core::num::Saturating;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #87920 <https://github.com/rust-lang/rust/issues/87920> for more information
    = help: add `#![feature(saturating_int_impl)]` to the crate attributes to enable
...
```