### PR TITLE
rmm: Enable FEAT_ECV to use CNTPOFF_EL2

### DIFF
--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -415,16 +415,15 @@ define_sys_register!(
     DFB[1 - 1],
     SRE[0 - 0]
 );
-//CNTHCTL_EL2: S3_4_C14_C1_0
-define_sys_register!(S3_4_C14_C1_0, EL1PCTEN[11 - 11], EL1PTEN[10 - 10]);
 
-define_sys_register!(CNTVOFF_EL2);
-define_sys_register!(CNTV_CVAL_EL0);
-define_sys_register!(CNTV_CTL_EL0);
-define_sys_register!(S3_4_C14_C0_6); // CNTPOFF_EL2
-define_sys_register!(CNTP_CVAL_EL0);
+define_sys_register!(CNTHCTL_EL2, EL1PCTEN[11 - 11], EL1PTEN[10 - 10]);
+define_sys_register!(CNTPOFF_EL2);
 define_sys_register!(CNTP_CTL_EL0);
+define_sys_register!(CNTP_CVAL_EL0);
 define_sys_register!(CNTVCT_EL0);
+define_sys_register!(CNTVOFF_EL2);
+define_sys_register!(CNTV_CTL_EL0);
+define_sys_register!(CNTV_CVAL_EL0);
 define_sys_register!(CNTV_TVAL_EL0);
 
 macro_rules! define_iss_id {

--- a/plat/fvp/.cargo/config.toml
+++ b/plat/fvp/.cargo/config.toml
@@ -4,4 +4,5 @@ target = "aarch64-unknown-none-softfloat"
 [target.aarch64-unknown-none-softfloat]
 rustflags = [
   "-C", "link-args=-Tplat/fvp/memory.x",
+  "-C", "target-feature=+ecv"
 ]

--- a/rmm/.cargo/config.toml
+++ b/rmm/.cargo/config.toml
@@ -1,2 +1,3 @@
 [build]
 target = "aarch64-unknown-none-softfloat"
+rustflags = ["-C", "target-feature=+ecv"]

--- a/rmm/src/realm/timer.rs
+++ b/rmm/src/realm/timer.rs
@@ -8,7 +8,7 @@ use armv9a::regs::*;
 
 pub fn init_timer(vcpu: &mut VCPU) {
     let timer = &mut vcpu.context.timer;
-    timer.cnthctl_el2 = S3_4_C14_C1_0::EL1PCTEN | S3_4_C14_C1_0::EL1PTEN;
+    timer.cnthctl_el2 = CNTHCTL_EL2::EL1PCTEN | CNTHCTL_EL2::EL1PTEN;
 }
 
 pub fn set_cnthctl(vcpu: &mut VCPU, val: u64) {
@@ -20,12 +20,12 @@ pub fn restore_state(vcpu: &VCPU) {
     let timer = &vcpu.context.timer;
 
     unsafe { CNTVOFF_EL2.set(timer.cntvoff_el2) };
-    unsafe { S3_4_C14_C0_6.set(timer.cntpoff_el2) }; // CNTPOFF_EL2
+    unsafe { CNTPOFF_EL2.set(timer.cntpoff_el2) };
     unsafe { CNTV_CVAL_EL0.set(timer.cntv_cval_el0) };
     unsafe { CNTV_CTL_EL0.set(timer.cntv_ctl_el0) };
     unsafe { CNTP_CVAL_EL0.set(timer.cntp_cval_el0) };
     unsafe { CNTP_CTL_EL0.set(timer.cntp_ctl_el0) };
-    unsafe { S3_4_C14_C1_0.set(timer.cnthctl_el2) }; // CNTHCTL_EL2
+    unsafe { CNTHCTL_EL2.set(timer.cnthctl_el2) };
 }
 
 pub fn save_state(vcpu: &mut VCPU) {
@@ -34,10 +34,10 @@ pub fn save_state(vcpu: &mut VCPU) {
     timer.cntvoff_el2 = unsafe { CNTVOFF_EL2.get() };
     timer.cntv_cval_el0 = unsafe { CNTV_CVAL_EL0.get() };
     timer.cntv_ctl_el0 = unsafe { CNTV_CTL_EL0.get() };
-    timer.cntpoff_el2 = unsafe { S3_4_C14_C0_6.get() }; // CNTPOFF_EL2
+    timer.cntpoff_el2 = unsafe { CNTPOFF_EL2.get() };
     timer.cntp_cval_el0 = unsafe { CNTP_CVAL_EL0.get() };
     timer.cntp_ctl_el0 = unsafe { CNTP_CTL_EL0.get() };
-    timer.cnthctl_el2 = unsafe { S3_4_C14_C1_0.get() };
+    timer.cnthctl_el2 = unsafe { CNTHCTL_EL2.get() };
 }
 
 pub fn send_state_to_host(rd: &mut Rd, vcpu: usize, run: &mut Run) -> Result<(), Error> {


### PR DESCRIPTION
This PR enables `FEAT_ECV` to use CNTPOFF_EL2.

We couldn't use the `CNTPOFF_EL2` register because `FEAT_ECV` was not enabled.
So we used `S3_4_C14_C0_6` as a workaround. 

According to the Arm specification, FEAT_ECV must be enabled to use `CNTPOFF_EL2`, so in this PR, i've enabled `FEAT_ECV` used the correct register name.

This PR emits an warning like below. However, it is better to use the correct target-feature to ensure proper functionality.
```rust
$ cargo build
warning: unknown and unstable feature specified for `-Ctarget-feature`: `ecv`
  |
  = note: it is still passed through to the codegen backend, but use of this feature might be unsound and the behavior of this feature can change in the future
  = help: consider filing a feature request
```
---

## Arm A-Profile Spec
### CNTPOFF_EL2, Counter-timer Physical Offset Register
This register is present only when FEAT_ECV is implemented. Otherwise, direct accesses to CNTPOFF_EL2 are UNDEFINED.

## LLVM Version (18.1.4)
ref) llvm/lib/Target/AArch64/AArch64SystemOperands.td

```cpp
// v8.6a Enhanced Counter Virtualization
//                                 Op0   Op1    CRn     CRm     Op2
let Requires = [{ {AArch64::FeatureEnhancedCounterVirtualization} }] in {
...
def : RWSysReg<"CNTPOFF_EL2",      0b11, 0b100, 0b1110, 0b0000, 0b110>;
...
}
```