### PR TITLE
ci: Enhance tests with inotifywait

### DIFF
--- a/scripts/deps/pkgs-for-ci.sh
+++ b/scripts/deps/pkgs-for-ci.sh
@@ -13,6 +13,7 @@ sudo apt install -y -qq --no-install-recommends \
 	jq lcov \
 	flex bison \
 	bzip2 \
+	inotify-tools \
 	srecord
 
 pip3 install toml

--- a/scripts/deps/pkgs.sh
+++ b/scripts/deps/pkgs.sh
@@ -18,6 +18,7 @@ sudo apt-get install -y -qq --no-install-recommends --fix-missing \
 	srecord \
 	git wget make vim bc pkg-config \
 	bridge-utils \
+	inotify-tools \
 	pylint
 
 pip3 install toml

--- a/scripts/tests/realm-boot.sh
+++ b/scripts/tests/realm-boot.sh
@@ -3,6 +3,8 @@
 ROOT=$(git rev-parse --show-toplevel)
 UART=$ROOT/out/uart0.log
 
+TIMEOUT=90
+
 [ -e $UART ] && rm $UART
 
 check_result()
@@ -29,6 +31,17 @@ tar -xf $ROOT/assets/prebuilt/out.tar.bz2 -C $ROOT
 $ROOT/scripts/fvp-cca -bo -rmm=islet --use-prebuilt --rmm-log-level=error
 $ROOT/scripts/fvp-cca -ro -nw=linux --realm=linux -rmm=islet --no-telnet &
 
-sleep 640
+sleep 10
+
+echo "[!] Starting realm-booting test..."
+
+while inotifywait -q -t $TIMEOUT -e modify $UART >/dev/null 2>&1; do
+	echo -n "."
+	if grep -q "buildroot login:" "$UART"; then
+		break
+	fi
+done
+
+echo ""
 
 check_result


### PR DESCRIPTION
This PR improves the ACS test and realm booting test.

- Using `inotifywait`, it terminates when a file is not changed for a specific amount of time.
- If the exit condition matches the last change, it exits immediately.
- The time required for `realm-booting job of CI` has been reduced by half. (about 15m -> 7m)