### PR TITLE
safe-abstraction: Apply to granule-locked structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,7 @@ name = "vmsa"
 version = "0.0.1"
 dependencies = [
  "armv9a",
+ "safe_abstraction",
  "spinning_top",
 ]
 

--- a/lib/vmsa/Cargo.toml
+++ b/lib/vmsa/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 
 [dependencies]
 armv9a = { path = "../armv9a" }
+safe_abstraction = { path = "../safe-abstraction" }
 spinning_top = "0.2.4"

--- a/rmm/src/realm/mm/stage2_tte.rs
+++ b/rmm/src/realm/mm/stage2_tte.rs
@@ -37,6 +37,32 @@ pub struct RttPage([u64; GRANULE_SIZE / size_of::<u64>()]);
 
 impl Content for RttPage {}
 
+impl safe_abstraction::raw_ptr::RawPtr for RttPage {}
+
+impl safe_abstraction::raw_ptr::SafetyChecked for RttPage {}
+
+impl safe_abstraction::raw_ptr::SafetyAssured for RttPage {
+    fn is_initialized(&self) -> bool {
+        // The initialization of this memory is guaranteed
+        // according to the RMM Specification A2.2.4 Granule Wiping.
+        // This instance belongs to a RTT Granule and has been initialized.
+        true
+    }
+
+    fn verify_ownership(&self) -> bool {
+        // The ownership of this instance is exclusively ensured by the RMM.
+        // under the following conditions:
+        //
+        // 1. A lock on the given address is obtained using the `get_granule*` macros.
+        // 2. The instance is converted from a raw pointer through the `content*` functions.
+        // 3. The instance is accessed only within the lock scope.
+        //
+        // Ownership verification is guaranteed because these criteria are satisfied
+        // in all cases where this object is accessed.
+        true
+    }
+}
+
 impl RttPage {
     pub fn len(&self) -> usize {
         self.0.len()

--- a/rmm/src/realm/rd.rs
+++ b/rmm/src/realm/rd.rs
@@ -101,6 +101,32 @@ impl Rd {
 
 impl Content for Rd {}
 
+impl safe_abstraction::raw_ptr::RawPtr for Rd {}
+
+impl safe_abstraction::raw_ptr::SafetyChecked for Rd {}
+
+impl safe_abstraction::raw_ptr::SafetyAssured for Rd {
+    fn is_initialized(&self) -> bool {
+        // The initialization of this memory is guaranteed
+        // according to the RMM Specification A2.2.4 Granule Wiping.
+        // This instance belongs to a RD Granule and has been initialized.
+        true
+    }
+
+    fn verify_ownership(&self) -> bool {
+        // The ownership of this instance is exclusively ensured by the RMM.
+        // under the following conditions:
+        //
+        // 1. A lock on the given address is obtained using the `get_granule*` macros.
+        // 2. The instance is converted from a raw pointer through the `content*` functions.
+        // 3. The instance is accessed only within the lock scope.
+        //
+        // Ownership verification is guaranteed because these criteria are satisfied
+        // in all cases where this object is accessed.
+        true
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum State {
     Null,

--- a/rmm/src/rec.rs
+++ b/rmm/src/rec.rs
@@ -244,6 +244,32 @@ impl Rec<'_> {
 
 impl Content for Rec<'_> {}
 
+impl safe_abstraction::raw_ptr::RawPtr for Rec<'_> {}
+
+impl safe_abstraction::raw_ptr::SafetyChecked for Rec<'_> {}
+
+impl safe_abstraction::raw_ptr::SafetyAssured for Rec<'_> {
+    fn is_initialized(&self) -> bool {
+        // The initialization of this memory is guaranteed
+        // according to the RMM Specification A2.2.4 Granule Wiping.
+        // This instance belongs to a REC Granule and has been initialized.
+        true
+    }
+
+    fn verify_ownership(&self) -> bool {
+        // The ownership of this instance is exclusively ensured by the RMM.
+        // under the following conditions:
+        //
+        // 1. A lock on the given address is obtained using the `get_granule*` macros.
+        // 2. The instance is converted from a raw pointer through the `content*` functions.
+        // 3. The instance is accessed only within the lock scope.
+        //
+        // Ownership verification is guaranteed because these criteria are satisfied
+        // in all cases where this object is accessed.
+        true
+    }
+}
+
 // XXX: is using 'static okay here?
 unsafe fn current() -> Option<&'static mut Rec<'static>> {
     match TPIDR_EL2.get() {

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -27,7 +27,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let rd = arg[0];
 
         let mut rd_granule = get_granule_if!(rd, GranuleState::RD)?;
-        let rd = rd_granule.content_mut::<Rd>();
+        let mut rd = rd_granule.content_mut::<Rd>()?;
 
         if !rd.at_state(State::New) {
             return Err(Error::RmiErrorRealm(0));
@@ -46,7 +46,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         }
 
         let mut rd_granule = get_granule_if!(rd, GranuleState::Delegated)?;
-        let rd_obj = rd_granule.content_mut::<Rd>();
+        let mut rd_obj = rd_granule.content_mut::<Rd>()?;
         #[cfg(not(kani))]
         // `page_table` is currently not reachable in model checking harnesses
         rmm.page_table.map(rd, true);
@@ -88,7 +88,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
         #[cfg(not(kani))]
         // `rsi` is currently not reachable in model checking harnesses
-        HashContext::new(rd_obj)?.measure_realm_create(&params)?;
+        HashContext::new(&mut rd_obj)?.measure_realm_create(&params)?;
 
         let mut eplilog = move || {
             let mut rtt_granule = get_granule_if!(rtt_base, GranuleState::Delegated)?;
@@ -118,7 +118,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         if rd_granule.num_children() > 0 {
             return Err(Error::RmiErrorRealm(0));
         }
-        let rd = rd_granule.content::<Rd>();
+        let rd = rd_granule.content::<Rd>()?;
         let vmid = rd.id();
 
         let mut rtt_granule = get_granule_if!(rd.rtt_base(), GranuleState::RTT)?;

--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -44,8 +44,8 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     });
 
     listen!(rsi, rsi::PSCI_CPU_ON, |_arg, ret, _rmm, rec, run| {
-        let mut rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
-        let rd = rd.content_mut::<Rd>();
+        let rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
+        let rd = rd.content::<Rd>()?;
 
         let target_mpidr = get_reg(rec, 1)? as u64;
         let entry_addr = get_reg(rec, 2)?;
@@ -87,7 +87,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, rsi::PSCI_SYSTEM_OFF, |_arg, ret, _rmm, rec, run| {
         let mut rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
-        let rd = rd.content_mut::<Rd>();
+        let mut rd = rd.content_mut::<Rd>()?;
         rd.set_state(State::SystemOff);
         run.set_exit_reason(rmi::EXIT_PSCI);
         run.set_gpr(0, rsi::PSCI_SYSTEM_OFF as u64)?;
@@ -109,7 +109,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
 
     listen!(rsi, rsi::PSCI_SYSTEM_RESET, |_arg, ret, _rmm, rec, run| {
         let mut rd = get_granule_if!(rec.owner()?, GranuleState::RD)?;
-        let rd = rd.content_mut::<Rd>();
+        let mut rd = rd.content_mut::<Rd>()?;
         rd.set_state(State::SystemOff);
         run.set_exit_reason(rmi::EXIT_PSCI);
         run.set_gpr(0, rsi::PSCI_SYSTEM_RESET as u64)?;

--- a/rmm/src/rsi/ripas.rs
+++ b/rmm/src/rsi/ripas.rs
@@ -21,7 +21,7 @@ pub fn get_ripas_state(
 ) -> core::result::Result<(), Error> {
     let ipa_bits = rec.ipa_bits()?;
     let rd_granule = get_granule_if!(rec.owner()?, GranuleState::RD)?;
-    let rd = rd_granule.content::<Rd>();
+    let rd = rd_granule.content::<Rd>()?;
 
     let ipa_page = get_reg(rec, 1)?;
     if validate_ipa(ipa_page, ipa_bits).is_err() {
@@ -32,7 +32,7 @@ pub fn get_ripas_state(
         return Ok(());
     }
 
-    let ripas = crate::rtt::get_ripas(rd, ipa_page, RTT_PAGE_LEVEL)? as usize;
+    let ripas = crate::rtt::get_ripas(&rd, ipa_page, RTT_PAGE_LEVEL)? as usize;
 
     debug!(
         "RSI_IPA_STATE_GET: ipa_page: {:X} ripas: {:X}",

--- a/rmm/src/rtt.rs
+++ b/rmm/src/rtt.rs
@@ -44,7 +44,7 @@ fn level_map_size(level: usize) -> usize {
 pub fn create(rd: &Rd, rtt_addr: usize, ipa: usize, level: usize) -> Result<(), Error> {
     let mut rtt_granule = get_granule_if!(rtt_addr, GranuleState::Delegated)?;
 
-    let s2tt = rtt_granule.content_mut::<RttPage>();
+    let mut s2tt = rtt_granule.content_mut::<RttPage>()?;
 
     let (parent_s2tte, last_level) = S2TTE::get_s2tte(rd, ipa, level - 1, Error::RmiErrorInput)?;
 


### PR DESCRIPTION
This PR applies safe abstraction to structures managed with granule locks.

1. The affected structures are RD, RTT and REC.
2. `content_mut` has been modified to manage `&mut` in accordance with Rust's syntax.
3. Four `unsafe` keyword have been removed.