### PR TITLE
fvp-cca: Support trace toggle in acs tests

### DIFF
--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -506,8 +506,8 @@ def run_fvp_acs(debug, trace, trace_toggle, no_telnet):
         print("[!] Enabling debug...")
         args += ["--debug"]
     if trace_toggle:
-        print("[!] Trace toggling not supported yet")
-        sys.exit(1)
+        print("[!] Enabling trace with toggle...")
+        args += ["--trace-toggle"]
     elif trace:
         print("[!] Enabling trace...")
         args += ["--trace"]


### PR DESCRIPTION
This PR enables `--trace-toggle` option for ACS tests. The option allows specifying the range of instruction tracing with Arm's `ToggleMTIPlugin`, helping to debug a subtle symptom. For example, it helped me to analyze `rmi_rec_enter`, when it was not working. The instruction toggling is controlled by pre-reserved `hlt 5` instruction.

[Pre-requisite]

The library (ToggleMTIPlugin.so) is not included in our simulator package. It should be manually located by installing another package such as `FastModelsPortfolio_11.25` which requires license agreement.

[Usage example]
```
(in plat/fvp/src/entry.rs)
unsafe extern "C" fn rmm_entry() -> ! {
    core::arch::asm!("
        msr spsel, #1
        bl get_cpu_id

+       hlt     5                   // trace start
        ldr x1, =__RMM_STACK_END__
        mov x2, {}
        mul x0, x0, x2
        sub x0, x1, x0
        mov sp, x0
+       hlt     5                   // trace end

$ ./scripts/fvp-cca -nw=acs --selected-tests="cmd_rsi_version" --trace-toggle

$ cat out/trace.log
141120780000 ps cluster0.cpu0 IT (14112078) fdc0000c 58000161 O EL2h_rl : LDR      x1,0xfdc00038
141120790000 ps cluster0.cpu0 IT (14112079) fdc00010 d2a00202 O EL2h_rl : MOV      x2,#0x100000
141120800000 ps cluster0.cpu0 IT (14112080) fdc00014 9b027c00 O EL2h_rl : MUL      x0,x0,x2
141120810000 ps cluster0.cpu0 IT (14112081) fdc00018 cb000020 O EL2h_rl : SUB      x0,x1,x0
141120820000 ps cluster0.cpu0 IT (14112082) fdc0001c 9100001f O EL2h_rl : ADD      sp,x0,#0
141120830000 ps cluster0.cpu0 IT (14112083) fdc00020 d44000a0 O EL2h_rl : HLT      #5
```
