### PR TITLE
Setup MIRI Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,9 @@ jobs:
     - name: Run unsafe analyzer
       run: ./scripts/unsafe-analyzer
 
+    - name: Run MIRI test
+      run: ./scripts/tests/miri.sh
+
     - uses: actions/upload-artifact@v3
       with:
         name: tools

--- a/rmm/src/event/mainloop.rs
+++ b/rmm/src/event/mainloop.rs
@@ -27,7 +27,7 @@ impl Mainloop {
     }
 
     #[cfg(not(kani))]
-    fn add_event_handlers(&mut self) {
+    pub fn add_event_handlers(&mut self) {
         rmi::features::set_event_handler(self);
         rmi::gpt::set_event_handler(self);
         rmi::realm::set_event_handler(self);

--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -18,14 +18,12 @@ macro_rules! listen {
 }
 
 pub type Command = usize;
-pub type Argument = [usize; 8];
-pub type Return = [usize; 8];
 
 #[derive(Clone)]
 pub struct Context {
-    cmd: Command,
-    arg: Vec<usize>,
-    ret: Vec<usize>,
+    pub cmd: Command,
+    pub arg: Vec<usize>,
+    pub ret: Vec<usize>,
 }
 
 impl Context {

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -11,7 +11,7 @@ pub mod allocator;
 pub mod asm;
 pub mod config;
 pub mod cpu;
-pub mod event;
+pub(crate) mod event;
 pub mod exception;
 pub mod gic;
 #[macro_use]
@@ -30,6 +30,8 @@ pub mod rsi;
 pub mod rtt;
 #[cfg(feature = "stat")]
 pub mod stat;
+#[cfg(test)]
+pub(crate) mod test_utils;
 #[macro_use]
 pub mod r#macro;
 mod measurement;

--- a/rmm/src/macro.rs
+++ b/rmm/src/macro.rs
@@ -100,10 +100,6 @@ mod test {
         pub fn output(&self) -> String {
             String::from_utf8(self.buffer.borrow().to_vec()).unwrap()
         }
-
-        pub fn clear(&mut self) {
-            self.buffer.borrow_mut().clear()
-        }
     }
 
     impl Device for MockDevice {

--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -88,3 +88,23 @@ pub fn validate(feat_reg0: usize) -> bool {
 
     true
 }
+
+#[cfg(test)]
+mod test {
+    use crate::rmi::{FEATURES, SUCCESS};
+    use crate::test_utils::*;
+
+    // Source: https://github.com/ARM-software/cca-rmm-acs
+    // Test Case: cmd_rmi_features_host
+    #[test]
+    fn rmi_features() {
+        let ret = rmi::<FEATURES>(&[0]);
+
+        assert_eq!(ret[0], SUCCESS);
+        assert_eq!(extract_bits(ret[1], 30, 63), 0);
+
+        let ret = rmi::<FEATURES>(&[1]);
+        assert_eq!(ret[0], SUCCESS);
+        assert_eq!(ret[1], 0);
+    }
+}

--- a/rmm/src/rmi/version.rs
+++ b/rmm/src/rmi/version.rs
@@ -40,3 +40,27 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 }
+
+#[cfg(test)]
+mod test {
+    use super::encode_version;
+    use crate::rmi::{ABI_MAJOR_VERSION, ABI_MINOR_VERSION, SUCCESS, VERSION};
+    use crate::test_utils::*;
+
+    // Source: https://github.com/ARM-software/cca-rmm-acs
+    // Test Case: cmd_rmi_version_host
+    #[test]
+    fn rmi_version() {
+        let ret = rmi::<VERSION>(&[encode_version()]);
+
+        assert_eq!(ret[0], SUCCESS);
+
+        // Must Be Zero fields
+        assert_eq!(extract_bits(ret[1], 31, 63), 0);
+        assert_eq!(extract_bits(ret[2], 31, 63), 0);
+
+        // Version Check
+        assert_eq!(extract_bits(ret[1], 0, 15), ABI_MINOR_VERSION);
+        assert_eq!(extract_bits(ret[1], 16, 30), ABI_MAJOR_VERSION);
+    }
+}

--- a/rmm/src/test_utils.rs
+++ b/rmm/src/test_utils.rs
@@ -1,0 +1,30 @@
+use crate::event::Context;
+use crate::event::Mainloop;
+use crate::monitor::Monitor;
+use alloc::vec::Vec;
+
+pub fn rmi<const COMMAND: usize>(arg: &[usize]) -> Vec<usize> {
+    let mut mainloop = Mainloop::new();
+    let monitor = Monitor::new();
+    (&mut mainloop).add_event_handlers();
+
+    let mut ctx = Context::new(COMMAND);
+    ctx.init_arg(&arg);
+    ctx.init_ret(&[0; 8]);
+
+    let handler = mainloop.on_event.get(&COMMAND).unwrap();
+    if let Err(code) = handler(&ctx.arg, &mut ctx.ret, &monitor) {
+        ctx.ret[0] = code.into();
+    }
+    ctx.ret.to_vec()
+}
+
+pub fn extract_bits(value: usize, start: u32, end: u32) -> usize {
+    let num_bits = end - start + 1;
+    let mask = if num_bits == usize::BITS {
+        usize::MAX
+    } else {
+        (1 << num_bits) - 1
+    };
+    (value >> start) & mask
+}

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -18,4 +18,5 @@ cargo clippy --lib -p islet_rmm -- \
 	-A clippy::new_without_default \
 	-A clippy::redundant_pattern_matching \
 	-A clippy::type_complexity \
+	-A clippy::upper-case-acronyms \
 	--deny "warnings"

--- a/scripts/init-unsafe-analysis.sh
+++ b/scripts/init-unsafe-analysis.sh
@@ -8,6 +8,8 @@ TOOL=$ROOT/third-party/cargo-geiger
 
 $HERE/deps/rust.sh
 
+rustup component add --toolchain nightly-2024-04-21-x86_64-unknown-linux-gnu miri
+
 git submodule update --init $TOOL
 cargo +stable install cargo-geiger --force --locked \
 	--path $TOOL/cargo-geiger \

--- a/scripts/tests/miri.sh
+++ b/scripts/tests/miri.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+ROOT=$(git rev-parse --show-toplevel)
+
+mkdir -p $ROOT/out
+
+cd $ROOT/rmm
+
+MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test --target aarch64-unknown-linux-gnu
+
+if [ $? -ne 0 ]; then
+	exit 1
+fi


### PR DESCRIPTION
This PR sets up [MIRI](https://github.com/rust-lang/miri) to analyze potential memory safety violations arising from unsafe code at the MIR level.

`MIRI` is an interpreter that performs analysis at the MIR (Mid-level Intermediate Representation) level. Tests must be expressible in MIR to be testable with `MIRI`. Consequently, we are leveraging some test cases from the ACS project, originally written in C, by rewriting them in Rust.

## Advantages of the Current Approach

To establish a Rust-based testing environment, I have added a `test_utils` module, allowing tests to be conducted at the function level rather than running the entire codebase. 

```rust
#[test]
fn rmi_features() {
  let ret = rmi::<FEATURES>(&[0]);
  assert_eq!(ret[0], SUCCESS);
  ...
}

#[test]
fn rmi_version() {
  let ret = rmi::<VERSION>(&[encode_version()]);
  assert_eq!(ret[0], SUCCESS);
  ...
}
```

This modular testing approach facilitates the use of various Rust verification tools, such as `MIRI` and `cargo-fuzzer`. Additionally, by adding an abstraction layer for assembly, I expect to enhance our capability to verify code using tools like `Kani`.

## Relationship with ACS Tests

This approach does have the drawback of duplicating tests already covered by `ACS`. However, it provides the significant advantage of enabling `Rust-based testing` without the need for an `ACS + FVP setup`. Considering these pros and cons, the next steps will focus on selectively incorporating ACS test cases that involve unsafe code flows into our Rust environment, rather than porting all ACS test cases.

This selective approach ensures we maintain a robust testing framework while leveraging Rust's advanced tooling for safety and verification.

## How to test
### MIRI Test
```sh
$ ./scripts/tests/miri.sh
running 10 tests
test r#macro::test::eprintln_with_format ... ok
test r#macro::test::eprintln_without_arg ... ok
test r#macro::test::eprintln_without_format ... ok
test r#macro::test::println_with_format ... ok
test r#macro::test::println_without_arg ... ok
test r#macro::test::println_without_format ... ok
test r#macro::test::set_of_const_assert ... ok
test rmi::features::test::rmi_features ... ok
test rmi::version::test::rmi_version ... ok
```

### Cross Test
```sh
$ ./scripts/tests/crates.sh
running 10 tests
test r#macro::test::eprintln_with_format ... ok
test r#macro::test::eprintln_without_arg ... ok
test r#macro::test::eprintln_without_format ... ok
test r#macro::test::println_with_format ... ok
test r#macro::test::println_without_arg ... ok
test r#macro::test::println_without_format ... ok
test r#macro::test::set_of_const_assert ... ok
test rmi::features::test::rmi_features ... ok
test rmi::version::test::rmi_version ... ok
```