### PR TITLE
Try to fix attestation and measurements bugs

### DIFF
--- a/lib/armv9a/src/lib.rs
+++ b/lib/armv9a/src/lib.rs
@@ -11,3 +11,16 @@ pub use regs::*;
 pub const fn bits_in_reg(mask: u64, val: u64) -> u64 {
     (val << (mask.trailing_zeros())) & mask
 }
+
+pub fn is_irq_pending() -> bool {
+    let val: u64;
+
+    unsafe {
+        core::arch::asm!(
+            "mrs {}, ISR_EL1",
+            out(reg) val
+        )
+    }
+
+    return val != 0;
+}

--- a/rmm/src/realm/rd.rs
+++ b/rmm/src/realm/rd.rs
@@ -29,12 +29,13 @@ pub struct Rd {
     rec_index: usize,
     s2_starting_level: isize,
     hash_algo: u8,
+    rpv: [u8; 64],
     pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
     pub vcpu_index: usize,
 }
 
 impl Rd {
-    pub fn init(&mut self, vmid: u16, rtt_base: usize, ipa_bits: usize, s2_starting_level: isize) {
+    pub fn init(&mut self, vmid: u16, rtt_base: usize, ipa_bits: usize, s2_starting_level: isize, rpv: [u8; 64]) {
         self.vmid = vmid;
         self.state = State::New;
         self.rtt_base = rtt_base;
@@ -43,6 +44,7 @@ impl Rd {
         self.s2_starting_level = s2_starting_level;
         self.measurements = [Measurement::empty(); MEASUREMENTS_SLOT_NR];
         self.vcpu_index = 0;
+        self.rpv.copy_from_slice(rpv.as_slice());
     }
 
     pub fn id(&self) -> usize {
@@ -96,6 +98,10 @@ impl Rd {
 
     pub fn set_hash_algo(&mut self, alg: u8) {
         self.hash_algo = alg;
+    }
+
+    pub fn personalization_value(&self) -> &[u8] {
+        self.rpv.as_slice()
     }
 }
 

--- a/rmm/src/rec.rs
+++ b/rmm/src/rec.rs
@@ -86,6 +86,7 @@ impl Rec<'_> {
         self.context = Context::new();
         self.context.sys_regs.vttbr = vttbr;
         self.context.sys_regs.vmpidr = vmpidr;
+        self.attest_state = RmmRecAttestState::NoAttestInProgress;
         timer::init_timer(self);
         gic::init_gic(self);
 

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -74,6 +74,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
                 params.rtt_base as usize,
                 params.ipa_bits(),
                 params.rtt_level_start as isize,
+                params.rpv
             )
         })?;
 

--- a/rmm/src/rsi/attestation/mod.rs
+++ b/rmm/src/rsi/attestation/mod.rs
@@ -62,11 +62,12 @@ impl Attestation {
         &self,
         challenge: &[u8],
         measurements: &[Measurement],
+        personalization_value: &[u8],
         hash_algo: u8,
     ) -> Vec<u8> {
         let mut cca_token = Vec::new();
 
-        let realm_token = self.create_realm_token(challenge, measurements, hash_algo);
+        let realm_token = self.create_realm_token(challenge, measurements, personalization_value, hash_algo);
 
         let realm_token_entry = (
             Value::Integer(CCA_REALM_DELEGATED_TOKEN.into()),
@@ -93,6 +94,7 @@ impl Attestation {
         &self,
         challenge: &[u8],
         measurements: &[Measurement],
+        personalization_value: &[u8],
         hash_algo: u8,
     ) -> Vec<u8> {
         let hash_algo_id = match hash_algo {
@@ -108,7 +110,7 @@ impl Attestation {
 
         let claims = RealmClaims::init(
             challenge,
-            &DUMMY_PERSONALIZATION_VALUE,
+            personalization_value,
             measurements,
             hash_algo_id,
             &public_key,
@@ -156,12 +158,13 @@ impl Attestation {
     }
 }
 
-pub fn get_token(challenge: &[u8], measurements: &[Measurement], hash_algo: u8) -> Vec<u8> {
+pub fn get_token(challenge: &[u8], measurements: &[Measurement], personalization_value: &[u8], hash_algo: u8) -> Vec<u8> {
     // TODO: consider storing attestation object somewhere,
     // as RAK and token do not change during rmm lifetime.
     Attestation::new(&plat_token(), &realm_attest_key()).create_attestation_token(
         challenge,
         measurements,
+        personalization_value,
         hash_algo,
     )
 }

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -133,7 +133,7 @@ fn get_token_part(
 
     // FIXME: This should be stored instead of generating it for every call.
     let token =
-        crate::rsi::attestation::get_token(context.attest_challenge(), &measurements, hash_algo);
+        crate::rsi::attestation::get_token(context.attest_challenge(), &measurements, rd.personalization_value(), hash_algo);
 
     let offset = context.attest_token_offset();
     let part_size = core::cmp::min(size, token.len() - offset);
@@ -149,7 +149,7 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         let mut challenge: [u8; 64] = [0; 64];
 
         for i in 0..8 {
-            let challenge_part = get_reg(rec, i + 2)?;
+            let challenge_part = get_reg(rec, i + 1)?;
             let start_idx = i * 8;
             let end_idx = start_idx + 8;
             challenge[start_idx..end_idx].copy_from_slice(&challenge_part.to_le_bytes());

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -8,6 +8,7 @@ pub mod ripas;
 pub mod version;
 
 use alloc::vec::Vec;
+use armv9a::is_irq_pending;
 
 use crate::define_interface;
 use crate::event::RsiHandle;
@@ -209,6 +210,14 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         // `rsi` is currently not reachable in model checking harnesses
         {
             let (token_part, token_left) = get_token_part(&rd, rec, buffer_size)?;
+
+            if is_irq_pending() {
+                error!("IRQ is pending while fetching token");
+                set_reg(rec, 0, INCOMPLETE)?;
+                set_reg(rec, 1, 0)?;
+                ret[0] = rmi::SUCCESS_REC_ENTER;
+                return Ok(());
+            }
 
             unsafe {
                 let pa_ptr = attest_pa as *mut u8;


### PR DESCRIPTION
This PR tries to resolve issues with tests regarding measurements and attestation. Currently, the results are as follows:

| 	|ACS TEST SUIT|	PASS/FAIL|
|-|-|-|
|1	|measurement_immutable_rim | PASS |
|2	|measurement_initial_rem_is_zero | PASS | 	 
|3	|measurement_rim_order	| PASS |
|4	|attestation_token_verify | PASS| 
|5	|attestation_rpv_value	 	 | PASS|
|6	|attestation_challenge_data_verification | PASS|	 	 
|7	|attestation_token_init	 	 | PASS|
|8	|attestation_realm_measurement_type	|PASS| 	 
|9	|attestation_platform_challenge_size	 |PASS|	 
|10|	attestation_rem_extend_check	 	 |PASS|
|11|	attestation_rem_extend_check_realm_token	|PASS| 	 
|12|	attestation_rec_exit_irq	 |!@???##&? |

Legend:
* __`!@???##&?`__ - This test passes only when I run it without others (using the `--selected-tests` option). As of now, I wasn't able to debug why the interrupt doesn't trigger when the entire test suite is running. Unfortunately, there are more problems with this test, which will be discussed later.

## Encountered issues

### Some simple mistakes (these were fixed and doesn't require further discussion)
* In `ATTEST_TOKEN_INIT` the challenge was read from wrong registers.
* During the attestation token generation, the Realm Personalization Value was stubbed.

### Using improperly initialized memory

Upon Realm's REC creation in the rmi `REC_CREATE` handler Islet does the following:
```rust=
        let mut rec_granule = get_granule_if!(rec, GranuleState::Delegated)?;
        #[cfg(not(kani))]
        // `page_table` is currently not reachable in model checking harnesses
        rmm.page_table.map(rec, true);
        let mut rec = rec_granule.content_mut::<Rec<'_>>()?;
```
It uses the `SafetyAssured` and `SafetyAssumed` traits to basically convert a raw pointer to a Rust reference. Later, the `rec` object is initialized by a safe function `Rec::init`:
```rust=
        match prepare_args(&mut rd, params.mpidr) {
            Ok((vcpuid, vttbr, vmpidr)) => {
                ret[1] = vcpuid;
                rec.init(owner, vcpuid, params.flags, vttbr, vmpidr)?;
            }
            Err(_) => return Err(Error::RmiErrorInput),
        }
```
Inside this `Rec::init` function, someone forgot to initialize the `attest_state` field. This is of course a simple mistake, but I think that it was caused by a bigger issue. I understand that Rust doesn't yet have any syntax allowing to construct an object in-place by providing some pointer. The current solution implemented in Islet is to cast the raw pointer to Rust reference and then call a some `init` function which assumes that it is operating on a valid object. That's why it is possible to forget about some fields in a constructor. I think we should discuss better ways of handling this issue, as either the `Rec::init` function should be made **unsafe** as this initialization is semantically unsafe, or we should design a better mechanism. Naturally, marking the init function as unsafe will not solve this problem, but it will be a warning that here Rust cannot ensure complete safety. The other solution might be to implement a mechanism similar to how the `Box` pointer can be created using a custom memory allocator. On the high level, this ensures that the created object will be placed in a memory region controlled by the provided allocator. In this scenario, the object is first created on the stack using the Rust typical struct creation syntax and is the moved to the allocated memory region. To minimize performance impact, Rust compiles relies on the LLVM framework to perform Return Value optimization. This should initialize the object directly in the destination, instead of copying it. In a nutshell, we could implement something like this:
```rust=
    /// Allocates memory in the given allocator then places `x` into it.
    ///
    /// This doesn't actually allocate if `T` is zero-sized.
    ///
    /// # Examples
    ///
    /// ```
    /// #![feature(allocator_api)]
    ///
    /// use std::alloc::System;
    ///
    /// let five = Box::new_in(5, System);
    /// ```
    #[cfg(not(no_global_oom_handling))]
    #[unstable(feature = "allocator_api", issue = "32838")]
    #[must_use]
    #[inline]
    pub fn new_in(x: T, alloc: A) -> Self
    where
        A: Allocator,
    {
        let mut boxed = Self::new_uninit_in(alloc);
        unsafe {
            boxed.as_mut_ptr().write(x);
            boxed.assume_init()
        }
    }
```
I quickly patched this issue by initializing the `attest_state` field inside the `Rec::init`. Nevertheless, I still think that we should discuss how to rework the Recs, and Rds initialization as this defeats the point of using Rust and really starts looking like C or C++.

### The __`!@???##&?`__ test

The `attestation_rec_exit_irq` attempts to test whether reading the attestation token from rmm can be interrupted by an IRQ. Since, the IRQ is a lower level exception, it cannot interrupt the control flow of Islet. As a result, it needs to be actively checked during RSI handling. For example, the TF-rmm does this as follows:
```c=
while (attest_data->token_sign_ctx.state == ATTEST_SIGN_IN_PROGRESS) {
	attest_token_continue_sign_state(attest_data, res);
	if (check_pending_irq()) {
		res->action = UPDATE_REC_EXIT_TO_HOST;
		rec_exit->exit_reason = RMI_EXIT_IRQ;
		return;
	}
}
```

In Islet this is currently impossible to recreate.
#### Issue 1
```rust=
pub fn get_token(challenge: &[u8], measurements: &[Measurement], hash_algo: u8) -> Vec<u8> {
    // TODO: consider storing attestation object somewhere,
    // as RAK and token do not change during rmm lifetime.
    Attestation::new(&plat_token(), &realm_attest_key()).create_attestation_token(
        challenge,
        measurements,
        hash_algo,
    )
}
```

... and ..
```rust=

fn get_token_part(
    rd: &Rd,
    context: &mut Rec<'_>,
    size: usize,
) -> core::result::Result<(Vec<u8>, usize), Error> {
    let hash_algo = rd.hash_algo();
    let measurements = rd.measurements;

    // FIXME: This should be stored instead of generating it for every call.
    let token =
        crate::rsi::attestation::get_token(context.attest_challenge(), &measurements, hash_algo);
```
To make this test work as ARM has intended, we should fix these two TODOs, as these issues are a performance nightmare. When the creation of the realm token will be interruptible by  IRQs we cannot regenerate the token every time the Realm asks for it.

#### Issue 2
```rust=
    fn sign(secret_key: p384::SecretKey, data: &[u8]) -> Vec<u8> {
        let signing_key = p384::ecdsa::SigningKey::from_bytes(&secret_key.to_bytes())
            .expect("Failed to generate signing key");

        let signature: p384::ecdsa::Signature = signing_key
            .try_sign(data)
            .expect("Failed to create P384 signature");
        signature.to_vec()
    }
```
This code is responsible for signing the attestation token. We must rewrite it to a "init, update, finish" type API to implement an IRQ checking loop similar to how TF-rmm does it.

### __DUCT TAPE__ solution
To make this test working, I applied the following makeshift:
```rust=
        {
            let (token_part, token_left) = get_token_part(&rd, rec, buffer_size)?;

            if is_irq_pending() {
                error!("IRQ is pending while fetching token");
                set_reg(rec, 0, INCOMPLETE)?;
                set_reg(rec, 1, 0)?;
                ret[0] = rmi::SUCCESS_REC_ENTER;
                return Ok(());
            }

            unsafe {
                let pa_ptr = attest_pa as *mut u8;
                core::ptr::copy(token_part.as_ptr(), pa_ptr.add(pa_offset), token_part.len());
            }
            if token_left == 0 {
                set_reg(rec, 0, SUCCESS)?;
                rec.set_attest_state(RmmRecAttestState::NoAttestInProgress);
            } else {
                set_reg(rec, 0, INCOMPLETE)?;
            }
            set_reg(rec, 1, token_part.len())?;
        }
```

The helper function:
```rust=
pub fn is_irq_pending() -> bool {
    let val: u64;

    unsafe {
        core::arch::asm!(
            "mrs {}, ISR_EL1",
            out(reg) val
        )
    }

    return val != 0;
}
```

Thanks to this, the test passes, but for some reason when I run the entire test suite it fails. Besides that, this solution is a performance nightmare as it generated the token and then checks for IRQ and discards the token if an IRQ is pending.

## Summary
This PR in its current state provides fixes and some makeshifts solutions that are necessary for the application provisioning to work. Naturally, the last test is not essential, as it only tests the performance and interrupt handling responsiveness. Nevertheless, we should fix it as will improve performance even on fvp emulator. 