### PR TITLE
Safe instance creation at given memory address

### DIFF
--- a/lib/vmsa/src/guard.rs
+++ b/lib/vmsa/src/guard.rs
@@ -40,6 +40,13 @@ impl<'a, E> EntryGuard<'a, E> {
     {
         raw_ptr::assume_safe::<T>(self.addr).or(Err(Error::MmErrorOthers))
     }
+
+    pub fn new_uninit_with<T>(&mut self, value: T) -> Result<raw_ptr::SafetyAssumed<T>, Error>
+    where
+        T: Content + raw_ptr::SafetyChecked + raw_ptr::SafetyAssured,
+    {
+        raw_ptr::assume_safe_uninit_with::<T>(self.addr, value).or(Err(Error::MmErrorOthers))
+    }
 }
 
 impl<'a, E> Deref for EntryGuard<'a, E> {

--- a/rmm/src/granule/array/entry.rs
+++ b/rmm/src/granule/array/entry.rs
@@ -98,6 +98,14 @@ impl Granule {
         Ok(raw_ptr::assume_safe::<T>(addr)?)
     }
 
+    pub fn new_uninit_with<T>(&mut self, value: T) -> Result<raw_ptr::SafetyAssumed<T>, Error>
+    where
+        T: Content + raw_ptr::SafetyChecked + raw_ptr::SafetyAssured,
+    {
+        let addr = self.index_to_addr();
+        Ok(raw_ptr::assume_safe_uninit_with::<T>(addr, value)?)
+    }
+
     pub fn content<T>(&self) -> Result<raw_ptr::SafetyAssumed<T>, Error>
     where
         T: Content + raw_ptr::SafetyChecked + raw_ptr::SafetyAssured,

--- a/rmm/src/rec.rs
+++ b/rmm/src/rec.rs
@@ -57,6 +57,29 @@ pub struct Rec<'a> {
 }
 
 impl Rec<'_> {
+    pub fn new() -> Self {
+        Self {
+            context: Context::new(),
+            attest_state: RmmRecAttestState::NoAttestInProgress,
+            attest_challenge: [0; MAX_CHALLENGE_SIZE],
+            attest_token_offset: 0,
+            owner: OnceCell::new(),
+            vcpuid: 0,
+            runnable: false,
+            psci_pending: false,
+            state: State::Ready,
+            ripas: Ripas {
+                start: 0,
+                end: 0,
+                addr: 0,
+                state: 0,
+                flags: 0,
+            },
+            vtcr: 0,
+            host_call_pending: false,
+        }
+    }
+
     pub fn init(
         &mut self,
         owner: usize,
@@ -80,13 +103,9 @@ impl Rec<'_> {
         }
 
         self.vcpuid = vcpuid;
-        self.set_ripas(0, 0, 0, 0);
         self.set_runnable(flags);
-        self.set_state(State::Ready);
-        self.context = Context::new();
         self.context.sys_regs.vttbr = vttbr;
         self.context.sys_regs.vmpidr = vmpidr;
-        self.attest_state = RmmRecAttestState::NoAttestInProgress;
         timer::init_timer(self);
         gic::init_gic(self);
 

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -70,8 +70,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         #[cfg(not(kani))]
         // `page_table` is currently not reachable in model checking harnesses
         rmm.page_table.map(rec, true);
-        let mut rec = rec_granule.content_mut::<Rec<'_>>()?;
-
+        let mut rec = rec_granule.new_uninit_with::<Rec<'_>>(Rec::new())?;
         match prepare_args(&mut rd, params.mpidr) {
             Ok((vcpuid, vttbr, vmpidr)) => {
                 ret[1] = vcpuid;


### PR DESCRIPTION
This PR presents a quick draft for safely creating an instance at a given memory address.
As discussed in https://github.com/islet-project/islet/pull/342, utilizing the idea proposed by @L0czek, this approach involves parsing the given address as uninitialized memory, then copying that instance to that address.

For REC and RD, the copy cost was not considered significant since the operation is called only once.

### Concept
```rust
// Create Instance
let addr = GIVEN_ADDRESS;
let value = T;
unsafe {
  let src: core::mem::MaybeUninit<T> = core::mem::MaybeUninit::new(value);
  let src = &src as *const core::mem::MaybeUninit<T>;
  let dst = addr as *mut core::mem::MaybeUninit<T>;
  core::ptr::copy_nonoverlapping(src, dst, 1);
}

// Access Instance
let ptr = addr as *mut core::mem::MaybeUninit<T>;
let value = (*ptr).assume_init_ref();
```

### API changed 
```rust
- let mut rec = rec_granule.content_mut::<Rec<'_>>()?;
+ let mut rec = rec_granule.new_uninit_with::<Rec<'_>>(Rec::new())?;
```