### PR TITLE
vmsa: introduce new_in() with an allocator as a parameter

### DIFF
--- a/lib/vmsa/src/page_table.rs
+++ b/lib/vmsa/src/page_table.rs
@@ -154,6 +154,7 @@ impl<A: Address, L: Level, E: Entry, const N: usize> PageTable<A, L, E, N> {
                 // the (uninitialized) previous contents of `entry`,
                 // though for the simple Entry with u64 would have worked using
                 // (*entry) = E::new();
+                // See https://github.com/zakarumych/allocator-api2/blob/main/src/stable/boxed.rs#L905
                 let e = E::new();
                 core::ptr::copy_nonoverlapping(&e, entry, 1);
                 core::mem::forget(e);

--- a/rmm/src/granule/page_table/mod.rs
+++ b/rmm/src/granule/page_table/mod.rs
@@ -114,7 +114,7 @@ macro_rules! get_granule {
                     let pa =
                         Page::<GranuleSize, PhysAddr>::including_address(PhysAddr::from($addr));
                     match gst
-                        .root_pgtlb
+                        .root_pgtbl
                         .entry(pa, 1, false, |e| page_table::Entry::lock(e))
                     {
                         Ok(guard) => match guard {

--- a/rmm/src/mm/page_table/entry.rs
+++ b/rmm/src/mm/page_table/entry.rs
@@ -89,7 +89,7 @@ impl page_table::Entry for Entry {
         Ok(())
     }
 
-    fn set_with_page_table_flags(&mut self, addr: PhysAddr) -> Result<(), Error> {
+    fn point_to_subtable(&mut self, _index: usize, addr: PhysAddr) -> Result<(), Error> {
         self.set(
             addr,
             armv9a::bits_in_reg(PTDesc::INDX, mair_idx::RMM_MEM)

--- a/rmm/src/realm/mm/page_table/entry.rs
+++ b/rmm/src/realm/mm/page_table/entry.rs
@@ -75,7 +75,7 @@ impl page_table::Entry for Entry {
         Ok(())
     }
 
-    fn set_with_page_table_flags(&mut self, addr: PhysAddr) -> Result<(), Error> {
+    fn point_to_subtable(&mut self, _index: usize, addr: PhysAddr) -> Result<(), Error> {
         self.set(
             addr,
             bits_in_reg(RawPTE::ATTR, pte::attribute::NORMAL_FWB)


### PR DESCRIPTION
The ulimate goal is to eliminate redundant functions for the realm s2 table management which are scattered across the board in rtt.rs, stage2_translation.rs, stage2_tte.rs, page.rs and lib/vmsa.
Prior to that, this PR does followings.
1. Create a page table with an allocator that the function caller provides.
2. Return as a reference and reduce unsafe usages.
3. Simplify mutiple look-alike functions into one.