### PR TITLE
examples/reliant-party: Update to new realm-verifier

### DIFF
--- a/examples/veraison/reliant-party/Cargo.toml
+++ b/examples/veraison/reliant-party/Cargo.toml
@@ -18,3 +18,4 @@ rust-rsi = { git = "https://github.com/islet-project/remote-attestation" }
 ratls = { git = "https://github.com/islet-project/remote-attestation" }
 realm-verifier = { git = "https://github.com/islet-project/remote-attestation" }
 veraison-verifier = { git = "https://github.com/islet-project/remote-attestation" }
+serde_json = "*"

--- a/examples/veraison/reliant-party/src/main.rs
+++ b/examples/veraison/reliant-party/src/main.rs
@@ -1,17 +1,14 @@
-use chrono::DateTime;
 use clap::Parser;
 use realm_verifier::{
-    parser::{parse_reference_json, ReferenceJSON},
-    MeasurementValue, RealmMeasurements, RealmVerifier,
+    parser_json::parse_value,
+    RealmVerifier,
 };
-use rust_rsi::CLAIM_COUNT_REALM_EXTENSIBLE_MEASUREMENTS;
-use std::{error::Error, fs::File, io::Read, sync::Arc};
-use tinyvec::ArrayVec;
+use std::{error::Error, fs::File, io::{Read, BufReader}, sync::Arc};
 
 use ratls::{ChainVerifier, RaTlsServer};
 use veraison_verifier::VeraisonTokenVerifer;
 
-use log::{debug, error, info};
+use log::{error, info};
 
 /// Creates a path to a resource file
 macro_rules! resource_file {
@@ -51,77 +48,14 @@ struct Cli {
     veraison_pubkey: String,
 }
 
-fn hash_algo_len(hash_algo: String) -> Result<usize, &'static str> {
-    match hash_algo.as_str() {
-        "sha-256" => Ok(32),
-        "sha-384" => Ok(48),
-        "sha-512" => Ok(64),
-        _ => Err("Invalid hash algorithm"),
-    }
-}
-
-fn verify_reference_json(
-    reference_json: ReferenceJSON,
-) -> Result<RealmMeasurements, Box<dyn Error>> {
-    // TODO: validate?
-    let _release_timestamp = DateTime::parse_from_rfc3339(&reference_json.realm.release_timestamp)?;
-
-    let hash_algo_len = hash_algo_len(reference_json.realm.reference_values.hash_algo)?;
-
-    let rim: MeasurementValue = hex::decode(reference_json.realm.reference_values.rim).unwrap()
-        [..hash_algo_len]
-        .iter()
-        .cloned()
-        .collect();
-    debug!("Reference RIM: {}", hex::encode(rim));
-    let mut rems = Vec::new();
-    for (rem_set_idx, string_rem_set) in reference_json
-        .realm
-        .reference_values
-        .rems
-        .iter()
-        .enumerate()
-    {
-        if string_rem_set.len() != CLAIM_COUNT_REALM_EXTENSIBLE_MEASUREMENTS {
-            return Err("REM set len is invalid".into());
-        }
-        debug!("Reference REM set[{}]:", rem_set_idx);
-
-        let mut rem_set = [ArrayVec::new(); CLAIM_COUNT_REALM_EXTENSIBLE_MEASUREMENTS];
-        for (rem_idx, string_rem) in string_rem_set.iter().enumerate() {
-            let rem: MeasurementValue = hex::decode(string_rem).unwrap().iter().cloned().collect();
-
-            if rem.len() < hash_algo_len {
-                return Err("Measurement len is too short for algorithm".into());
-            }
-
-            rem_set[rem_idx] = rem[0..hash_algo_len].iter().cloned().collect();
-            debug!("REM[{}]: {:?}", rem_idx, hex::encode(rem_set[rem_idx]));
-        }
-        rems.push(rem_set);
-    }
-
-    Ok(RealmMeasurements {
-        initial: rim,
-        extensible: rems,
-    })
-}
-
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
     let args = Cli::parse();
 
-    let reference_json = parse_reference_json(args.reference_json).map_err(|e| {
-        error!("Failed to parse reference json: {:?}", e);
-        e
-    })?;
+    let json_reader = BufReader::new(File::open(args.reference_json)?);
+    let mut reference_json: serde_json::Value = serde_json::from_reader(json_reader)?;
 
-    debug!("reference_json: {:#?}", reference_json);
-
-    let realm_measurements = verify_reference_json(reference_json).map_err(|e| {
-        error!("Reference json is not valid: {:?}", e);
-        e
-    })?;
+    let reference_measurements = parse_value(reference_json["realm"]["reference-values"].take())?;
 
     let mut pubkey = String::new();
     let mut file = File::open(args.veraison_pubkey).map_err(|e| {
@@ -133,7 +67,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let server = RaTlsServer::new(ratls::ServerMode::AttestedClient {
         client_token_verifier: Arc::new(ChainVerifier::new(vec![
             Arc::new(VeraisonTokenVerifer::new(args.veraison_url, pubkey)),
-            Arc::new(RealmVerifier::init(realm_measurements)),
+            Arc::new(RealmVerifier::init(reference_measurements)),
         ])),
         server_certificate_path: args.server_cert,
         server_privatekey_path: args.server_privkey,


### PR DESCRIPTION
This change depends on https://github.com/islet-project/remote-attestation/pull/7, which simplifies the usage of realm-verification structures.

To verify either wait for merge or modify Cargo.toml entry for realm-verifier using path to local clone of repo instead of git address.