### PR TITLE
Revert "Use DUCT-TAPE to fix irq test"

### DIFF
--- a/lib/armv9a/src/lib.rs
+++ b/lib/armv9a/src/lib.rs
@@ -11,16 +11,3 @@ pub use regs::*;
 pub const fn bits_in_reg(mask: u64, val: u64) -> u64 {
     (val << (mask.trailing_zeros())) & mask
 }
-
-pub fn is_irq_pending() -> bool {
-    let val: u64;
-
-    unsafe {
-        core::arch::asm!(
-            "mrs {}, ISR_EL1",
-            out(reg) val
-        )
-    }
-
-    val != 0
-}

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -8,7 +8,6 @@ pub mod ripas;
 pub mod version;
 
 use alloc::vec::Vec;
-use armv9a::is_irq_pending;
 
 use crate::define_interface;
 use crate::event::RsiHandle;
@@ -214,14 +213,6 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
         // `rsi` is currently not reachable in model checking harnesses
         {
             let (token_part, token_left) = get_token_part(&rd, rec, buffer_size)?;
-
-            if is_irq_pending() {
-                error!("IRQ is pending while fetching token");
-                set_reg(rec, 0, INCOMPLETE)?;
-                set_reg(rec, 1, 0)?;
-                ret[0] = rmi::SUCCESS_REC_ENTER;
-                return Ok(());
-            }
 
             unsafe {
                 let pa_ptr = attest_pa as *mut u8;


### PR DESCRIPTION
This reverts commit 2e0f9ffa672f526c91b5a6128cb70df082f33fd4.

It appears that some (maybe Islet) is not handling some IRQ properly. As a result this patch broke reading the attestation token even though the cca-rmm-acs tests were passing. It it most likely due to the fact that the test suite was a simple bare metal binary that doesn't utilize much of the emulated hardware. Reverting this patch doesn't remove any functionality. In the future, the IRQ handling should be investigated.