### PR TITLE
    realm/mm: RMI_RTT_FOLD support

### DIFF
--- a/plat/fvp/.cargo/config.toml
+++ b/plat/fvp/.cargo/config.toml
@@ -4,5 +4,6 @@ target = "aarch64-unknown-none-softfloat"
 [target.aarch64-unknown-none-softfloat]
 rustflags = [
   "-C", "link-args=-Tplat/fvp/memory.x",
-  "-C", "target-feature=+ecv"
+  "-C", "target-feature=+ecv",
+  "-C", "target-feature=+tlb-rmi"
 ]

--- a/rmm/.cargo/config.toml
+++ b/rmm/.cargo/config.toml
@@ -1,3 +1,6 @@
 [build]
 target = "aarch64-unknown-none-softfloat"
-rustflags = ["-C", "target-feature=+ecv"]
+rustflags = [
+  "-C", "target-feature=+ecv",
+  "-C", "target-feature=+tlb-rmi"
+]

--- a/rmm/src/granule/page_table/entry.rs
+++ b/rmm/src/granule/page_table/entry.rs
@@ -244,7 +244,7 @@ impl page_table::Entry for Entry {
         Some(PhysAddr::from(self.0.lock().addr()))
     }
 
-    fn set(&mut self, addr: PhysAddr, flags: u64, _is_raw: bool) -> Result<(), Error> {
+    fn set(&mut self, addr: PhysAddr, flags: u64) -> Result<(), Error> {
         self.0.lock().set_state(addr, flags)
     }
 

--- a/rmm/src/granule/page_table/translation.rs
+++ b/rmm/src/granule/page_table/translation.rs
@@ -53,7 +53,7 @@ impl GranuleStatusTable<'_, '_> {
         }
         let pa1 = Page::<GranuleSize, PhysAddr>::including_address(PhysAddr::from(addr));
         let pa2 = Page::<GranuleSize, PhysAddr>::including_address(PhysAddr::from(addr));
-        self.root_pgtbl.set_page(pa1, pa2, state, false)
+        self.root_pgtbl.set_page(pa1, pa2, state)
     }
 }
 

--- a/rmm/src/mm/page.rs
+++ b/rmm/src/mm/page.rs
@@ -10,5 +10,8 @@ pub enum BasePageSize {}
 impl PageSize for BasePageSize {
     const SIZE: usize = PAGE_SIZE;
     const MAP_TABLE_LEVEL: usize = 3;
-    const MAP_EXTRA_FLAG: u64 = bits_in_reg(PTDesc::TYPE, attr::page_type::TABLE_OR_PAGE);
+    const MAP_EXTRA_FLAG: u64 = bits_in_reg(PTDesc::TYPE, attr::page_type::TABLE_OR_PAGE)
+        | bits_in_reg(PTDesc::SH, attr::shareable::INNER)
+        | bits_in_reg(PTDesc::VALID, 1)
+        | bits_in_reg(PTDesc::AF, 1);
 }

--- a/rmm/src/mm/page_table/entry.rs
+++ b/rmm/src/mm/page_table/entry.rs
@@ -67,15 +67,8 @@ impl page_table::Entry for Entry {
         }
     }
 
-    fn set(&mut self, addr: PhysAddr, flags: u64, is_raw: bool) -> Result<(), Error> {
-        if is_raw {
-            self.0.set(addr.as_u64() | flags);
-        } else {
-            self.0
-                .set(addr.as_u64() | flags)
-                .set_masked_value(PTDesc::SH, attr::shareable::INNER)
-                .set_bits(PTDesc::AF | PTDesc::VALID);
-        }
+    fn set(&mut self, addr: PhysAddr, flags: u64) -> Result<(), Error> {
+        self.0.set(addr.as_u64() | flags);
 
         unsafe {
             core::arch::asm!(
@@ -90,12 +83,13 @@ impl page_table::Entry for Entry {
     }
 
     fn point_to_subtable(&mut self, _index: usize, addr: PhysAddr) -> Result<(), Error> {
-        self.set(
-            addr,
-            armv9a::bits_in_reg(PTDesc::INDX, mair_idx::RMM_MEM)
-                | armv9a::bits_in_reg(PTDesc::TYPE, attr::page_type::TABLE_OR_PAGE),
-            false,
-        )
+        let mut flags = PTDesc::new(0);
+        flags
+            .set_masked_value(PTDesc::INDX, mair_idx::RMM_MEM)
+            .set_masked_value(PTDesc::TYPE, attr::page_type::TABLE_OR_PAGE)
+            .set_masked_value(PTDesc::SH, attr::shareable::INNER)
+            .set_bits(PTDesc::AF | PTDesc::VALID);
+        self.set(addr, flags.get())
     }
 
     fn index<L: Level>(addr: usize) -> usize {

--- a/rmm/src/mm/translation.rs
+++ b/rmm/src/mm/translation.rs
@@ -128,11 +128,7 @@ impl<'a> Inner<'a> {
         let virtaddr = Page::<BasePageSize, VirtAddr>::range_with_size(va, size);
         let phyaddr = Page::<BasePageSize, PhysAddr>::range_with_size(phys, size);
 
-        if self
-            .root_pgtbl
-            .set_pages(virtaddr, phyaddr, flags, false)
-            .is_err()
-        {
+        if self.root_pgtbl.set_pages(virtaddr, phyaddr, flags).is_err() {
             warn!("set_pages error");
         }
     }

--- a/rmm/src/realm/mm/mod.rs
+++ b/rmm/src/realm/mm/mod.rs
@@ -10,6 +10,7 @@ pub mod table_level;
 use crate::rmi::error::Error;
 use core::ffi::c_void;
 use core::fmt::Debug;
+use core::slice::Iter;
 
 use address::{GuestPhysAddr, PhysAddr};
 use stage2_translation::Tlbi;
@@ -28,4 +29,9 @@ pub trait IPATranslation: Debug + Send + Sync {
     ) -> Result<(), Error>;
     fn clean(&mut self, vmid: usize);
     fn space_size(&self, level: usize) -> usize;
+    fn entries(
+        &self,
+        guest: GuestPhysAddr,
+        level: usize,
+    ) -> Result<(Iter<'_, entry::Entry>, usize), Error>;
 }

--- a/rmm/src/realm/mm/mod.rs
+++ b/rmm/src/realm/mm/mod.rs
@@ -12,14 +12,20 @@ use core::ffi::c_void;
 use core::fmt::Debug;
 
 use address::{GuestPhysAddr, PhysAddr};
+use stage2_translation::Tlbi;
 
 pub trait IPATranslation: Debug + Send + Sync {
     fn get_base_address(&self) -> *const c_void;
     // TODO: remove mut
     fn ipa_to_pa(&mut self, guest: GuestPhysAddr, level: usize) -> Option<PhysAddr>;
     fn ipa_to_pte(&mut self, guest: GuestPhysAddr, level: usize) -> Option<(u64, usize)>;
-    fn ipa_to_pte_set(&mut self, guest: GuestPhysAddr, level: usize, val: u64)
-        -> Result<(), Error>;
-    fn clean(&mut self);
+    fn ipa_to_pte_set(
+        &mut self,
+        guest: GuestPhysAddr,
+        level: usize,
+        val: u64,
+        invalidate: Tlbi,
+    ) -> Result<(), Error>;
+    fn clean(&mut self, vmid: usize);
     fn space_size(&self, level: usize) -> usize;
 }

--- a/rmm/src/realm/mm/page.rs
+++ b/rmm/src/realm/mm/page.rs
@@ -1,7 +1,9 @@
 use super::attribute::page_type;
 use super::stage2_tte::S2TTE;
+use super::table_level::{L1Table, L2Table, L3Table};
 use crate::config::{HUGE_PAGE_SIZE, LARGE_PAGE_SIZE, PAGE_SIZE};
 use vmsa::page::PageSize;
+use vmsa::page_table::Level;
 
 use armv9a::bits_in_reg;
 
@@ -10,7 +12,7 @@ use armv9a::bits_in_reg;
 pub enum BasePageSize {}
 impl PageSize for BasePageSize {
     const SIZE: usize = PAGE_SIZE;
-    const MAP_TABLE_LEVEL: usize = 3;
+    const MAP_TABLE_LEVEL: usize = L3Table::THIS_LEVEL;
     const MAP_EXTRA_FLAG: u64 = bits_in_reg(S2TTE::TYPE, page_type::TABLE_OR_PAGE);
 }
 
@@ -19,8 +21,8 @@ impl PageSize for BasePageSize {
 pub enum LargePageSize {}
 impl PageSize for LargePageSize {
     const SIZE: usize = LARGE_PAGE_SIZE;
-    const MAP_TABLE_LEVEL: usize = 2;
-    const MAP_EXTRA_FLAG: u64 = 0;
+    const MAP_TABLE_LEVEL: usize = L2Table::THIS_LEVEL;
+    const MAP_EXTRA_FLAG: u64 = bits_in_reg(S2TTE::TYPE, page_type::BLOCK);
 }
 
 #[derive(Clone, Copy)]
@@ -28,6 +30,6 @@ impl PageSize for LargePageSize {
 pub enum HugePageSize {}
 impl PageSize for HugePageSize {
     const SIZE: usize = HUGE_PAGE_SIZE;
-    const MAP_TABLE_LEVEL: usize = 1;
-    const MAP_EXTRA_FLAG: u64 = 0;
+    const MAP_TABLE_LEVEL: usize = L1Table::THIS_LEVEL;
+    const MAP_EXTRA_FLAG: u64 = bits_in_reg(S2TTE::TYPE, page_type::BLOCK);
 }

--- a/rmm/src/realm/mm/rtt.rs
+++ b/rmm/src/realm/mm/rtt.rs
@@ -241,9 +241,6 @@ pub fn get_ripas(rd: &Rd, ipa: usize, level: usize) -> Result<u64, Error> {
     Ok(s2tte.get_ripas())
 }
 
-// FIXME: cca-rmm-acs and linux realm is using old version of entry state.
-// i.e. no differentiation between (un)assigned and (un)assigned_ns
-// while RMM spec defines each individually.
 pub fn read_entry(rd: &Rd, ipa: usize, level: usize) -> Result<[usize; 4], Error> {
     let (s2tte, last_level) = S2TTE::get_s2tte(rd, ipa, level, Error::RmiErrorRtt(0))?;
 

--- a/rmm/src/realm/mm/rtt.rs
+++ b/rmm/src/realm/mm/rtt.rs
@@ -86,10 +86,7 @@ pub fn create(rd: &Rd, rtt_addr: usize, ipa: usize, level: usize) -> Result<(), 
 
         let flags = parent_s2tte.get_masked(S2TTE::INVALID_HIPAS | S2TTE::INVALID_RIPAS);
 
-        let pa: usize = parent_s2tte
-            .addr_as_block(level - 1)
-            .ok_or(Error::RmiErrorRtt(0))?
-            .into(); //XXX: check this again
+        let pa: usize = parent_s2tte.addr_as_block(level - 1).into(); //XXX: check this again
 
         create_pgtbl_at(rtt_addr, flags, pa, map_size)?;
     } else if parent_s2tte.is_assigned_ram(level - 1) {
@@ -100,10 +97,7 @@ pub fn create(rd: &Rd, rtt_addr: usize, ipa: usize, level: usize) -> Result<(), 
             flags |= bits_in_reg(S2TTE::DESC_TYPE, desc_type::L012_BLOCK);
         }
 
-        let pa: usize = parent_s2tte
-            .addr_as_block(level - 1)
-            .ok_or(Error::RmiErrorRtt(0))?
-            .into(); //XXX: check this again
+        let pa: usize = parent_s2tte.addr_as_block(level - 1).into(); //XXX: check this again
 
         create_pgtbl_at(rtt_addr, flags, pa, map_size)?;
         invalidate = Tlbi::LEAF(rd.id());
@@ -144,10 +138,7 @@ pub fn destroy<F: FnMut(usize)>(
         return Err(Error::RmiErrorRtt(last_level));
     }
 
-    let rtt_addr = parent_s2tte
-        .addr_as_block(RTT_PAGE_LEVEL)
-        .ok_or(Error::RmiErrorInput)?
-        .into();
+    let rtt_addr = parent_s2tte.addr_as_block(RTT_PAGE_LEVEL).into();
 
     let mut g_rtt = get_granule_if!(rtt_addr, GranuleState::RTT)?;
 
@@ -258,20 +249,14 @@ pub fn read_entry(rd: &Rd, ipa: usize, level: usize) -> Result<[usize; 4], Error
         };
     } else if s2tte.is_assigned_empty() {
         r2 = rtt_entry_state::RMI_ASSIGNED;
-        r3 = s2tte
-            .addr_as_block(last_level)
-            .ok_or(Error::RmiErrorRtt(0))?
-            .into(); //XXX: check this again
+        r3 = s2tte.addr_as_block(last_level).into(); //XXX: check this again
         r4 = invalid_ripas::EMPTY as usize;
     } else if s2tte.is_assigned_destroyed() {
         r2 = rtt_entry_state::RMI_ASSIGNED;
         r4 = invalid_ripas::DESTROYED as usize;
     } else if s2tte.is_assigned_ram(last_level) {
         r2 = rtt_entry_state::RMI_ASSIGNED;
-        r3 = s2tte
-            .addr_as_block(last_level)
-            .ok_or(Error::RmiErrorRtt(0))?
-            .into(); //XXX: check this again
+        r3 = s2tte.addr_as_block(last_level).into(); //XXX: check this again
         r4 = invalid_ripas::RAM as usize;
     } else if s2tte.is_assigned_ns(last_level) {
         r2 = rtt_entry_state::RMI_ASSIGNED;
@@ -281,10 +266,7 @@ pub fn read_entry(rd: &Rd, ipa: usize, level: usize) -> Result<[usize; 4], Error
         r4 = invalid_ripas::EMPTY as usize;
     } else if s2tte.is_table(last_level) {
         r2 = rtt_entry_state::RMI_TABLE;
-        r3 = s2tte
-            .addr_as_block(RTT_PAGE_LEVEL)
-            .ok_or(Error::RmiErrorRtt(0))?
-            .into(); //XXX: check this again
+        r3 = s2tte.addr_as_block(RTT_PAGE_LEVEL).into(); //XXX: check this again
         r4 = invalid_ripas::EMPTY as usize;
     } else {
         error!("Unexpected S2TTE value retrieved!");
@@ -397,10 +379,7 @@ pub fn set_ripas(rd: &Rd, base: usize, top: usize, ripas: u8, flags: u64) -> Res
         if level != last_level {
             break;
         }
-        let pa: usize = s2tte
-            .addr_as_block(last_level)
-            .ok_or(Error::RmiErrorRtt(0))?
-            .into(); //XXX: check this again
+        let pa: usize = s2tte.addr_as_block(last_level).into(); //XXX: check this again
         if ripas as u64 == invalid_ripas::EMPTY {
             new_s2tte |= bits_in_reg(S2TTE::INVALID_RIPAS, invalid_ripas::EMPTY);
 
@@ -536,10 +515,7 @@ pub fn data_destroy<F: FnMut(usize)>(
         return Err(Error::RmiErrorRtt(last_level));
     }
 
-    let pa = s2tte
-        .addr_as_block(last_level)
-        .ok_or(Error::RmiErrorRtt(last_level))?
-        .into(); //XXX: check this again
+    let pa = s2tte.addr_as_block(last_level).into(); //XXX: check this again
 
     let mut flags = bits_in_reg(S2TTE::INVALID_HIPAS, invalid_hipas::UNASSIGNED);
     if s2tte.is_assigned_ram(RTT_PAGE_LEVEL) {

--- a/rmm/src/realm/mm/stage2_translation.rs
+++ b/rmm/src/realm/mm/stage2_translation.rs
@@ -175,7 +175,7 @@ macro_rules! to_pte {
 macro_rules! set_pte {
     ($root:expr, $guest:expr, $level:expr, $val:expr) => {
         $root.entry($guest, $level, true, |entry| {
-            let _ = entry.set(PhysAddr::from(0 as u64), $val, true); //FIXME: get pa
+            let _ = entry.set(PhysAddr::from(0 as u64), $val); //FIXME: get pa
             Ok(None)
         })
     };

--- a/rmm/src/realm/mm/stage2_tte.rs
+++ b/rmm/src/realm/mm/stage2_tte.rs
@@ -147,7 +147,8 @@ impl S2TTE {
     }
 
     pub fn is_assigned(&self) -> bool {
-        self.get_masked_value(S2TTE::DESC_TYPE) == desc_type::LX_INVALID
+        self.get_masked_value(S2TTE::NS) == 0
+            && self.get_masked_value(S2TTE::DESC_TYPE) == desc_type::LX_INVALID
             && self.get_masked_value(S2TTE::INVALID_HIPAS) == invalid_hipas::ASSIGNED
     }
 

--- a/rmm/src/realm/mm/stage2_tte.rs
+++ b/rmm/src/realm/mm/stage2_tte.rs
@@ -198,12 +198,12 @@ impl S2TTE {
             && (self.get_ripas() != invalid_ripas::RAM)
     }
 
-    pub fn addr_as_block(&self, level: usize) -> Option<PhysAddr> {
+    pub fn addr_as_block(&self, level: usize) -> PhysAddr {
         match level {
-            1 => Some(PhysAddr::from(self.get_masked(S2TTE::ADDR_BLK_L1))),
-            2 => Some(PhysAddr::from(self.get_masked(S2TTE::ADDR_BLK_L2))),
-            3 => Some(PhysAddr::from(self.get_masked(S2TTE::ADDR_BLK_L3))),
-            _ => None,
+            1 => PhysAddr::from(self.get_masked(S2TTE::ADDR_BLK_L1)),
+            2 => PhysAddr::from(self.get_masked(S2TTE::ADDR_BLK_L2)),
+            3 => PhysAddr::from(self.get_masked(S2TTE::ADDR_BLK_L3)),
+            _ => unreachable!(),
         }
     }
 

--- a/rmm/src/realm/rd.rs
+++ b/rmm/src/realm/rd.rs
@@ -1,5 +1,3 @@
-use crate::rmi::rtt::realm_par_size;
-
 use vmsa::guard::Content;
 
 use crate::measurement::{Measurement, MEASUREMENTS_SLOT_NR};
@@ -94,9 +92,16 @@ impl Rd {
         self.rec_index += 1;
     }
 
-    pub fn addr_in_par(&self, addr: usize) -> bool {
-        let ipa_bits = self.ipa_bits();
-        addr < realm_par_size(ipa_bits)
+    pub fn ipa_size(&self) -> usize {
+        1 << self.ipa_bits
+    }
+
+    pub fn par_size(&self) -> usize {
+        self.ipa_size() / 2
+    }
+
+    pub fn addr_in_par(&self, ipa: usize) -> bool {
+        ipa < self.par_size()
     }
 
     pub fn hash_algo(&self) -> u8 {

--- a/rmm/src/rmi/constraint.rs
+++ b/rmm/src/rmi/constraint.rs
@@ -47,6 +47,7 @@ fn pick(cmd: Command) -> Option<Constraint> {
         rmi::RTT_DESTROY => Constraint::new(rmi::RTT_DESTROY, 4, 3),
         rmi::RTT_INIT_RIPAS => Constraint::new(rmi::RTT_INIT_RIPAS, 4, 2),
         rmi::RTT_SET_RIPAS => Constraint::new(rmi::RTT_SET_RIPAS, 5, 2),
+        rmi::RTT_FOLD => Constraint::new(rmi::RTT_FOLD, 4, 2),
         rmi::REQ_COMPLETE => Constraint::new(rmi::REQ_COMPLETE, 4, 2),
         rmi::PSCI_COMPLETE => Constraint::new(rmi::PSCI_COMPLETE, 4, 1),
         _ => return None,

--- a/rmm/src/rmi/mod.rs
+++ b/rmm/src/rmi/mod.rs
@@ -79,28 +79,3 @@ pub const EXIT_PSCI: u8 = 3;
 pub const EXIT_RIPAS_CHANGE: u8 = 4;
 pub const EXIT_HOST_CALL: u8 = 5;
 pub const EXIT_SERROR: u8 = 6;
-
-pub struct MapProt(usize);
-
-impl From<usize> for MapProt {
-    fn from(prot: usize) -> Self {
-        Self(prot)
-    }
-}
-
-impl MapProt {
-    pub fn new(data: usize) -> Self {
-        MapProt(data)
-    }
-    pub fn set_bit(&mut self, prot: u64) {
-        self.0 |= 1 << prot;
-    }
-    pub fn get(&self) -> usize {
-        self.0
-    }
-    pub fn is_set(&self, prot: u64) -> bool {
-        (self.0 >> prot) & 1 == 1
-    }
-    pub const DEVICE: u64 = 0;
-    pub const NS_PAS: u64 = 1;
-}

--- a/rmm/src/rmi/mod.rs
+++ b/rmm/src/rmi/mod.rs
@@ -65,9 +65,6 @@ pub const ERROR_REC: usize = 3;
 pub const SUCCESS_REC_ENTER: usize = 4;
 
 // RmiRttEntryState represents the state of an RTTE
-// FIXME: cca-rmm-acs and linux realm is using old version of entry state.
-// i.e. There is no differentiation between (un)assigned and (un)assigned_ns
-// while RMM spec defines each individually.
 pub mod rtt_entry_state {
     pub const RMI_UNASSIGNED: usize = 0;
     pub const RMI_ASSIGNED: usize = 1;

--- a/rmm/src/rmi/mod.rs
+++ b/rmm/src/rmi/mod.rs
@@ -30,6 +30,7 @@ define_interface! {
          RTT_READ_ENTRY         = 0xc400_0161,
          PSCI_COMPLETE          = 0xc400_0164,
          FEATURES               = 0xc400_0165,
+         RTT_FOLD               = 0xc400_0166,
          REC_AUX_COUNT          = 0xc400_0167,
          RTT_INIT_RIPAS         = 0xc400_0168,
          RTT_SET_RIPAS          = 0xc400_0169,
@@ -64,6 +65,9 @@ pub const ERROR_REC: usize = 3;
 pub const SUCCESS_REC_ENTER: usize = 4;
 
 // RmiRttEntryState represents the state of an RTTE
+// FIXME: cca-rmm-acs and linux realm is using old version of entry state.
+// i.e. There is no differentiation between (un)assigned and (un)assigned_ns
+// while RMM spec defines each individually.
 pub mod rtt_entry_state {
     pub const RMI_UNASSIGNED: usize = 0;
     pub const RMI_ASSIGNED: usize = 1;

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -54,7 +54,9 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         if rtt_addr == arg[0] {
             return Err(Error::RmiErrorInput);
         }
+        let mut rtt_granule = get_granule_if!(rtt_addr, GranuleState::Delegated)?;
         rtt::create(&rd, rtt_addr, ipa, level)?;
+        set_granule(&mut rtt_granule, GranuleState::RTT)?;
         Ok(())
     });
 


### PR DESCRIPTION
    1. Implement RTT_FOLD RMI.    
      - Added an RMI handler for RTT_FOLD.
      - Provide an iterator for the entry enumeration in a table at a specific level in PageTable and use the iterator when rtt.rs needs to access the whole entries at a time like rtt-fold.
    3. Fix errors in rtt found during the fold test.
      - Fix errors in subtable access in PageTable
      - Fix implementations that doesn't comply with RMM spec.
     4. Tlb invalidation for state2 translation table
      - added two versions of range invalidation, just for case that being unable to use tlb-rmi support.
     5. Misc
        - Move realm address space related checks which depends on ipa_bits to Rd.
        - Remove is_raw() param of set() in Entry
       
```
REGRESSION REPORT:
==================
   TOTAL TESTS     : 100
   TOTAL PASSED    : 92
   TOTAL FAILED    : 2
   TOTAL SKIPPED   : 5
   TOTAL SIM ERROR : 1

******* END OF ACS *******

```

[ Todo's but not in this scope ]
1. Implement more to pass acs-tests all.
```
Suite=gic : gic_timer_rel1_trig
Suite=pmu_debug : pmu_overflow
Suite=memory_management : mm_hipas_assigned_ripas_empty_da_ia
Suite=memory_management : mm_hipas_unassigned_ripas_empty_da_ia
Suite=gic : gic_timer_rel1_trig
Suite=pmu_debug : pmu_overflow
Suite=memory_management : mm_hipas_assigned_ripas_empty_da_ia
Suite=memory_management : mm_hipas_unassigned_ripas_empty_da_ia
```

3. Thoroughly review each rmi whether it complies with RMI spec.
4. Utilize the table entry enumerator more for other functions in rtt.