### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/getting-started/plat-dev.md
+++ b/doc/getting-started/plat-dev.md
@@ -29,7 +29,7 @@ $ ./launch-realm.sh
 $ cd /shared
 
 // Insert RSI kernel module
-$ inmod rsi.ko
+$ insmod rsi.ko
 
 // Run the sample app (rust)
 $ ./sdk-example


### PR DESCRIPTION
Changed inmod rsi.ko to insmod rsi.ko in the doc/getting-started/plat-dev.md file.