### PR TITLE
Fix a spec violation in realm destroy

### DIFF
--- a/rmm/src/realm/rd.rs
+++ b/rmm/src/realm/rd.rs
@@ -23,6 +23,7 @@ pub struct Rd {
     vmid: u16,
     state: State,
     rtt_base: usize,
+    rtt_num_start: usize,
     ipa_bits: usize,
     rec_index: usize,
     s2_starting_level: isize,
@@ -37,6 +38,7 @@ impl Rd {
         &mut self,
         vmid: u16,
         rtt_base: usize,
+        rtt_num_start: usize,
         ipa_bits: usize,
         s2_starting_level: isize,
         rpv: [u8; 64],
@@ -44,6 +46,7 @@ impl Rd {
         self.vmid = vmid;
         self.state = State::New;
         self.rtt_base = rtt_base;
+        self.rtt_num_start = rtt_num_start;
         self.ipa_bits = ipa_bits;
         self.rec_index = 0;
         self.s2_starting_level = s2_starting_level;
@@ -74,6 +77,10 @@ impl Rd {
 
     pub fn rtt_base(&self) -> usize {
         self.rtt_base
+    }
+
+    pub fn rtt_num_start(&self) -> usize {
+        self.rtt_num_start
     }
 
     pub fn ipa_bits(&self) -> usize {

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -75,6 +75,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             rd_obj.init(
                 params.vmid,
                 params.rtt_base as usize,
+                params.rtt_num_start as usize,
                 params.ipa_bits(),
                 params.rtt_level_start as isize,
                 params.rpv,
@@ -122,12 +123,17 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let rd = rd_granule.content::<Rd>()?;
         let vmid = rd.id();
 
-        let mut rtt_granule = get_granule_if!(rd.rtt_base(), GranuleState::RTT)?;
         #[cfg(feature = "gst_page_table")]
         if rd_granule.num_children() > 0 {
             return Err(Error::RmiErrorRealm(0));
         }
-        set_granule(&mut rtt_granule, GranuleState::Delegated)?;
+
+        let rtt_base = rd.rtt_base();
+        for i in 0..rd.rtt_num_start() {
+            let rtt = rtt_base + i * GRANULE_SIZE;
+            let mut rtt_granule = get_granule_if!(rtt, GranuleState::RTT)?;
+            set_granule(&mut rtt_granule, GranuleState::Delegated)?;
+        }
 
         // change state when everything goes fine.
         set_granule(&mut rd_granule, GranuleState::Delegated)?;

--- a/scripts/tests/acs.sh
+++ b/scripts/tests/acs.sh
@@ -3,8 +3,7 @@
 set -e
 
 # Control these variables
-# TODO: increase it after fixing `mm_rtt_level_start` and `mm_ha_hd_access`
-EXPECTED=74
+EXPECTED=76
 TIMEOUT=30
 
 ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
This PR fixes a spec violation regarding rtt_state in B4.3.10.3, found during the process of verification. As a result, it fixes the previous issue on ACS tests (mm_rtt_level_start and mm_ha_hd_access), described in #366.

The state should be updated by the number of `rtt_num_start`.

```
B4.3.10.3 Success conditions
rtt_state RttsStateEqual(
              realm.rtt_base, realm.rtt_num_start, DELEGATED)
```