### PR TITLE
Cover all RMIs with MIRI testing

### DIFF
--- a/rmm/src/asm.rs
+++ b/rmm/src/asm.rs
@@ -1,7 +1,7 @@
 use core::arch::asm;
 
 pub const SMC_SUCCESS: usize = 0;
-#[cfg(kani)]
+#[cfg(any(kani, miri, test))]
 pub const SMC_ERROR: usize = 1;
 
 pub fn smc(cmd: usize, args: &[usize]) -> [usize; 8] {
@@ -22,7 +22,7 @@ pub fn smc(cmd: usize, args: &[usize]) -> [usize; 8] {
     };
     put(&mut ret);
     put(&mut padded_args);
-    #[cfg(kani)]
+    #[cfg(any(kani, miri, test))]
     if cmd == crate::rmi::gpt::MARK_REALM {
         use crate::get_granule;
         use crate::granule::entry::GranuleGpt;
@@ -50,7 +50,7 @@ pub fn smc(cmd: usize, args: &[usize]) -> [usize; 8] {
     }
 
     // TODO: support more number of registers than 8 if needed
-    #[cfg(not(kani))]
+    #[cfg(not(any(kani, miri, test)))]
     unsafe {
         asm!(
             "smc #0x0",

--- a/rmm/src/granule/array/entry.rs
+++ b/rmm/src/granule/array/entry.rs
@@ -148,6 +148,16 @@ impl Granule {
     #[cfg(not(kani))]
     fn zeroize(&mut self) {
         let addr = self.index_to_addr();
+
+        // Safety: This operation writes to a Granule outside the RMM Memory region,
+        //         thus not violating RMM's Memory Safety.
+        //         (ref. RMM Specification A2.2.4 Granule Wiping)
+        //
+        // MIRI: This involves writing to memory not allocated by RMM,
+        //       which casues a no provenance error in MIRI.
+        //       This behavior is intentional and correct according to above reason.
+        //       Therefore, this code is excluded from MIRI test.
+        #[cfg(not(miri))]
         unsafe {
             core::ptr::write_bytes(addr as *mut u8, 0x0, GRANULE_SIZE);
         }

--- a/rmm/src/granule/array/entry.rs
+++ b/rmm/src/granule/array/entry.rs
@@ -160,9 +160,9 @@ impl Granule {
     #[cfg(any(kani, miri, test))]
     // DIFF: calculate addr using GRANULE_REGION
     pub fn index_to_addr(&self) -> usize {
-        use crate::granule::GRANULE_REGION;
+        use crate::granule::{GRANULE_REGION, GRANULE_STATUS_TABLE_SIZE};
         let idx = self.index();
-        assert!(idx >= 0 && idx < 8);
+        assert!(idx >= 0 && idx < GRANULE_STATUS_TABLE_SIZE);
 
         #[cfg(any(miri, test))]
         return crate::test_utils::align_up(unsafe {

--- a/rmm/src/granule/array/entry.rs
+++ b/rmm/src/granule/array/entry.rs
@@ -70,7 +70,6 @@ impl Granule {
 
         #[cfg(any(miri, test))]
         {
-            let state = GranuleState::Undelegated;
             Self {
                 state: GranuleState::Undelegated,
                 gpt: GranuleGpt::GPT_NS,
@@ -145,8 +144,7 @@ impl Granule {
         let entry_addr = granule_addr - granule_offset;
         let gst = &GRANULE_STATUS_TABLE;
         let table_base = gst.entries.as_ptr() as usize;
-        let index = (entry_addr - table_base) / core::mem::size_of::<Entry>();
-        index
+        (entry_addr - table_base) / core::mem::size_of::<Entry>()
     }
 
     #[cfg(not(any(kani, miri, test)))]
@@ -162,7 +160,7 @@ impl Granule {
     pub fn index_to_addr(&self) -> usize {
         use crate::granule::{GRANULE_REGION, GRANULE_STATUS_TABLE_SIZE};
         let idx = self.index();
-        assert!(idx >= 0 && idx < GRANULE_STATUS_TABLE_SIZE);
+        assert!(idx < GRANULE_STATUS_TABLE_SIZE);
 
         #[cfg(any(miri, test))]
         return crate::test_utils::align_up(unsafe {

--- a/rmm/src/granule/array/entry.rs
+++ b/rmm/src/granule/array/entry.rs
@@ -1,4 +1,4 @@
-use crate::granule::array::{align_up, GRANULE_STATUS_TABLE};
+use crate::granule::array::GRANULE_STATUS_TABLE;
 use crate::rmi::error::Error;
 
 use super::{GranuleState, GRANULE_SIZE};
@@ -165,7 +165,9 @@ impl Granule {
         assert!(idx >= 0 && idx < 8);
 
         #[cfg(any(miri, test))]
-        return align_up(unsafe { GRANULE_REGION.as_ptr() as usize + (idx * GRANULE_SIZE) });
+        return crate::test_utils::align_up(unsafe {
+            GRANULE_REGION.as_ptr() as usize + (idx * GRANULE_SIZE)
+        });
 
         #[cfg(kani)]
         return unsafe { GRANULE_REGION.as_ptr() as usize + (idx * GRANULE_SIZE) };

--- a/rmm/src/granule/array/mod.rs
+++ b/rmm/src/granule/array/mod.rs
@@ -24,9 +24,9 @@ pub(super) const FVP_DRAM1_REGION: core::ops::Range<usize> = core::ops::Range {
 pub(super) const FVP_DRAM1_IDX: usize =
     (FVP_DRAM0_REGION.end - FVP_DRAM0_REGION.start) / GRANULE_SIZE;
 
-#[cfg(any(kani, miri))]
+#[cfg(any(kani, miri, test))]
 pub const GRANULE_MEM_SIZE: usize = GRANULE_SIZE * GRANULE_STATUS_TABLE_SIZE;
-#[cfg(any(kani, miri))]
+#[cfg(any(kani, miri, test))]
 // We model the Host memory as a pre-allocated memory region which
 // can avoid a false positive related to invalid memory accesses
 // in model checking. Also, instead of using the same starting
@@ -36,14 +36,14 @@ pub const GRANULE_MEM_SIZE: usize = GRANULE_SIZE * GRANULE_STATUS_TABLE_SIZE;
 // distinguished from null pointer in CBMC.
 pub static mut GRANULE_REGION: [u8; GRANULE_MEM_SIZE] = [0; GRANULE_MEM_SIZE];
 
-#[cfg(miri)]
+#[cfg(any(miri, test))]
 pub fn granule_addr(idx: usize) -> usize {
     let start = unsafe { GRANULE_REGION.as_ptr() as usize };
     let first = align_up(start);
     first + idx * GRANULE_SIZE
 }
 
-#[cfg(miri)]
+#[cfg(any(miri, test))]
 fn align_up(addr: usize) -> usize {
     let align_mask = GRANULE_SIZE - 1;
     if addr & align_mask == 0 {
@@ -53,7 +53,7 @@ fn align_up(addr: usize) -> usize {
     }
 }
 
-#[cfg(not(any(kani, miri)))]
+#[cfg(not(any(kani, miri, test)))]
 pub fn validate_addr(addr: usize) -> bool {
     if addr % GRANULE_SIZE != 0 {
         // if the address is out of range.
@@ -67,7 +67,7 @@ pub fn validate_addr(addr: usize) -> bool {
     }
     true
 }
-#[cfg(any(kani, miri))]
+#[cfg(any(kani, miri, test))]
 // DIFF: check against GRANULE_REGION
 pub fn validate_addr(addr: usize) -> bool {
     if addr % GRANULE_SIZE != 0 {
@@ -80,7 +80,7 @@ pub fn validate_addr(addr: usize) -> bool {
     addr >= g_start && addr < g_end
 }
 
-#[cfg(not(any(kani, miri)))]
+#[cfg(not(any(kani, miri, test)))]
 pub fn granule_addr_to_index(addr: usize) -> usize {
     if FVP_DRAM0_REGION.contains(&addr) {
         return (addr - FVP_DRAM0_REGION.start) / GRANULE_SIZE;
@@ -90,7 +90,7 @@ pub fn granule_addr_to_index(addr: usize) -> usize {
     }
     usize::MAX
 }
-#[cfg(any(kani, miri))]
+#[cfg(any(kani, miri, test))]
 // DIFF: calculate index using GRANULE_REGION
 pub fn granule_addr_to_index(addr: usize) -> usize {
     let g_start = unsafe { GRANULE_REGION.as_ptr() as usize };
@@ -133,10 +133,12 @@ lazy_static! {
     pub static ref GRANULE_STATUS_TABLE: GranuleStatusTable = GranuleStatusTable::new();
 }
 
-#[cfg(not(kani))]
+#[cfg(not(any(kani, miri, test)))]
 pub const GRANULE_STATUS_TABLE_SIZE: usize = 0xfc000; // == RMM_MAX_GRANULES
 #[cfg(kani)]
 pub const GRANULE_STATUS_TABLE_SIZE: usize = 6;
+#[cfg(any(miri, test))]
+pub const GRANULE_STATUS_TABLE_SIZE: usize = 55;
 
 pub struct GranuleStatusTable {
     pub entries: [Entry; GRANULE_STATUS_TABLE_SIZE],

--- a/rmm/src/granule/array/mod.rs
+++ b/rmm/src/granule/array/mod.rs
@@ -34,7 +34,7 @@ pub const GRANULE_MEM_SIZE: usize = GRANULE_SIZE * GRANULE_STATUS_TABLE_SIZE;
 // non-deterministic contents. It helps to address an issue related
 // to the backend CBMC's pointer encoding, as 0x8000_0000 cannot be
 // distinguished from null pointer in CBMC.
-pub const GRANULE_REGION: [u8; GRANULE_MEM_SIZE] = [0; GRANULE_MEM_SIZE];
+pub static GRANULE_REGION: [u8; GRANULE_MEM_SIZE] = [0; GRANULE_MEM_SIZE];
 
 #[cfg(not(kani))]
 pub fn validate_addr(addr: usize) -> bool {

--- a/rmm/src/granule/array/mod.rs
+++ b/rmm/src/granule/array/mod.rs
@@ -39,23 +39,6 @@ pub const GRANULE_MEM_SIZE: usize = GRANULE_SIZE * GRANULE_STATUS_TABLE_SIZE;
 //       so the last region cannot be utilized.
 pub static mut GRANULE_REGION: [u8; GRANULE_MEM_SIZE] = [0; GRANULE_MEM_SIZE];
 
-#[cfg(any(miri, test))]
-pub fn granule_addr(idx: usize) -> usize {
-    let start = unsafe { GRANULE_REGION.as_ptr() as usize };
-    let first = align_up(start);
-    first + idx * GRANULE_SIZE
-}
-
-#[cfg(any(miri, test))]
-fn align_up(addr: usize) -> usize {
-    let align_mask = GRANULE_SIZE - 1;
-    if addr & align_mask == 0 {
-        addr
-    } else {
-        (addr | align_mask) + 1
-    }
-}
-
 #[cfg(not(any(kani, miri, test)))]
 pub fn validate_addr(addr: usize) -> bool {
     if addr % GRANULE_SIZE != 0 {

--- a/rmm/src/granule/array/mod.rs
+++ b/rmm/src/granule/array/mod.rs
@@ -34,6 +34,9 @@ pub const GRANULE_MEM_SIZE: usize = GRANULE_SIZE * GRANULE_STATUS_TABLE_SIZE;
 // non-deterministic contents. It helps to address an issue related
 // to the backend CBMC's pointer encoding, as 0x8000_0000 cannot be
 // distinguished from null pointer in CBMC.
+//
+// NOTE: In MIRI and test evironments, aligned addresses are used,
+//       so the last region cannot be utilized.
 pub static mut GRANULE_REGION: [u8; GRANULE_MEM_SIZE] = [0; GRANULE_MEM_SIZE];
 
 #[cfg(any(miri, test))]
@@ -165,7 +168,6 @@ macro_rules! get_granule {
         use crate::granule::array::{GRANULE_STATUS_TABLE, GRANULE_STATUS_TABLE_SIZE};
         use crate::granule::{granule_addr_to_index, validate_addr};
         use crate::rmi::error::Error;
-
         if !validate_addr($addr) {
             Err(Error::RmiErrorInput)
         } else {

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -21,7 +21,7 @@ pub(crate) mod host;
 pub mod logger;
 pub mod mm;
 pub mod mmio;
-#[cfg(not(any(test, kani)))]
+#[cfg(not(any(test, kani, miri)))]
 pub mod panic;
 pub mod realm;
 pub mod rec;

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -29,7 +29,7 @@ pub mod rmi;
 pub mod rsi;
 #[cfg(feature = "stat")]
 pub mod stat;
-#[cfg(test)]
+#[cfg(any(test, miri))]
 pub(crate) mod test_utils;
 #[macro_use]
 pub mod r#macro;

--- a/rmm/src/mm/page_table/entry.rs
+++ b/rmm/src/mm/page_table/entry.rs
@@ -70,6 +70,7 @@ impl page_table::Entry for Entry {
     fn set(&mut self, addr: PhysAddr, flags: u64) -> Result<(), Error> {
         self.0.set(addr.as_u64() | flags);
 
+        #[cfg(not(miri))]
         unsafe {
             core::arch::asm!(
                 "dsb ishst",

--- a/rmm/src/mm/page_table/entry.rs
+++ b/rmm/src/mm/page_table/entry.rs
@@ -70,7 +70,7 @@ impl page_table::Entry for Entry {
     fn set(&mut self, addr: PhysAddr, flags: u64) -> Result<(), Error> {
         self.0.set(addr.as_u64() | flags);
 
-        #[cfg(not(miri))]
+        #[cfg(not(any(miri, test)))]
         unsafe {
             core::arch::asm!(
                 "dsb ishst",

--- a/rmm/src/mm/translation.rs
+++ b/rmm/src/mm/translation.rs
@@ -51,6 +51,10 @@ pub fn get_page_table() -> u64 {
     page_table.get_base_address() as u64
 }
 
+pub fn drop_page_table() {
+    RMM_PAGE_TABLE.lock().root_pgtbl.drop();
+}
+
 struct Inner<'a> {
     // We will set the translation granule with 4KB.
     // To reduce the level of page lookup, initial lookup will start from L1.

--- a/rmm/src/realm/mm/entry.rs
+++ b/rmm/src/realm/mm/entry.rs
@@ -59,6 +59,7 @@ impl page_table::Entry for Entry {
     fn set(&mut self, addr: PhysAddr, flags: u64) -> Result<(), Error> {
         self.0.set(addr.as_u64() | flags);
 
+        #[cfg(not(any(miri, test)))]
         unsafe {
             core::arch::asm!(
                 "dsb ishst",

--- a/rmm/src/realm/mm/stage2_translation.rs
+++ b/rmm/src/realm/mm/stage2_translation.rs
@@ -394,10 +394,12 @@ impl<'a> IPATranslation for Stage2Translation<'a> {
         if let Ok(_x) = res {
             match invalidate {
                 Tlbi::LEAF(vmid) => {
+                    #[cfg(not(any(miri, test)))]
                     Self::tlbi_by_vmid_ipa(level, map_addr, vmid);
                     self.dirty = true;
                 }
                 Tlbi::BREAKDOWN(vmid) => {
+                    #[cfg(not(any(miri, test)))]
                     Self::tlbi_by_vmid_ipa_range(level, map_addr, vmid);
                     self.dirty = true;
                 }

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -34,7 +34,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             }?;
 
             #[cfg(not(feature = "gst_page_table"))]
-            let mut granule = get_granule_if!(addr, GranuleState::Undelegated)?;
+            let _granule = get_granule_if!(addr, GranuleState::Undelegated)?;
         }
 
         if smc(MARK_REALM, &[addr])[0] != SMC_SUCCESS {
@@ -63,7 +63,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let addr = arg[0];
         {
             // Avoid deadlock in get_granule() in smc
-            let granule = get_granule_if!(addr, GranuleState::Delegated)?;
+            let _granule = get_granule_if!(addr, GranuleState::Delegated)?;
         }
 
         if smc(MARK_NONSECURE, &[addr])[0] != SMC_SUCCESS {
@@ -93,7 +93,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
 #[cfg(test)]
 mod test {
-    use crate::granule::array::granule_addr;
     use crate::rmi::gpt::GranuleState;
     use crate::rmi::{ERROR_INPUT, GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
     use crate::test_utils::*;
@@ -103,7 +102,7 @@ mod test {
 
     #[test]
     fn rmi_granule_delegate_positive() {
-        let mocking_addr = granule_addr(0);
+        let mocking_addr = alloc_granule(0);
         let ret = rmi::<GRANULE_DELEGATE>(&[mocking_addr]);
         assert_eq!(ret[0], SUCCESS);
         assert!(get_granule_if!(mocking_addr, GranuleState::Delegated).is_ok());

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -81,13 +81,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
 #[cfg(test)]
 mod test {
-    use crate::rmi::{ERROR_INPUT, GRANULE_DELEGATE, SUCCESS};
+    use crate::rmi::{ERROR_INPUT, GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
     use crate::test_utils::*;
 
     use alloc::vec;
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
-    // Test Case: cmd_granule_delegate_host
+    // Test Case: cmd_granule_delegate
     /*
        Check 1 : gran_align; intent id : 0x0 addr : 0x88300001
        Check 2 : gran_bound; intent id : 0x1 addr : 0x1C0B0000
@@ -112,6 +112,34 @@ mod test {
 
         for (input, output) in test_data {
             let ret = rmi::<GRANULE_DELEGATE>(&[input]);
+            assert_eq!(output, ret[0]);
+        }
+    }
+
+    // Source: https://github.com/ARM-software/cca-rmm-acs
+    // Test Case: cmd_granule_undelegate
+    /*
+       Check 1 : gran_align; intent id : 0x0 addr : 0x88300001
+       Check 2 : gran_bound; intent id : 0x1 addr : 0x1C0B0000
+       Check 3 : gran_bound; intent id : 0x2 addr : 0x1000000001000
+       Check 4 : gran_state; intent id : 0x3 addr : 0x8830C000
+       Check 5 : gran_state; intent id : 0x4 addr : 0x88315000
+       Check 6 : gran_state; intent id : 0x5 addr : 0x88351000
+       Check 7 : gran_state; intent id : 0x6 addr : 0x88306000
+       Check 8 : gran_state; intent id : 0x7 addr : 0x88303000
+    */
+    #[test]
+    fn rmi_granule_undelegate() {
+        let test_data = vec![
+            (0x88300001, ERROR_INPUT),
+            (0x1C0B0000, ERROR_INPUT),
+            (0x1000000001000, ERROR_INPUT),
+            (0x8830C000, ERROR_INPUT),
+            // TODO: Cover all test data
+        ];
+
+        for (input, output) in test_data {
+            let ret = rmi::<GRANULE_UNDELEGATE>(&[input]);
             assert_eq!(output, ret[0]);
         }
     }

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -39,6 +39,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         #[cfg(not(kani))]
         // `page_table` is currently not reachable in model checking harnesses
         rmm.page_table.map(addr, true);
+
         set_granule(&mut granule, GranuleState::Delegated).map_err(|e| {
             #[cfg(not(kani))]
             // `page_table` is currently not reachable in model checking harnesses

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -102,7 +102,7 @@ mod test {
 
     #[test]
     fn rmi_granule_delegate_positive() {
-        let mocking_addr = alloc_granule(0);
+        let mocking_addr = mock::host::alloc_granule(IDX_RD);
         let ret = rmi::<GRANULE_DELEGATE>(&[mocking_addr]);
         assert_eq!(ret[0], SUCCESS);
         assert!(get_granule_if!(mocking_addr, GranuleState::Delegated).is_ok());

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -110,6 +110,8 @@ mod test {
         let ret = rmi::<GRANULE_UNDELEGATE>(&[mocking_addr]);
         assert_eq!(ret[0], SUCCESS);
         assert!(get_granule_if!(mocking_addr, GranuleState::Undelegated).is_ok());
+
+        miri_teardown();
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
@@ -167,5 +169,7 @@ mod test {
             let ret = rmi::<GRANULE_UNDELEGATE>(&[input]);
             assert_eq!(output, ret[0]);
         }
+
+        miri_teardown();
     }
 }

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod params;
-use self::params::Params;
+pub(crate) use self::params::Params;
 use super::error::Error;
 use crate::event::Mainloop;
 use crate::granule::GRANULE_SIZE;
@@ -164,10 +164,8 @@ fn create_realm(vmid: usize) -> Result<(), Error> {
 mod test {
     use crate::granule::array::granule_addr;
     use crate::realm::rd::{Rd, State};
-    use crate::rmi::realm::Params;
     use crate::rmi::{
-        ERROR_INPUT, GRANULE_DELEGATE, GRANULE_UNDELEGATE, REALM_ACTIVATE, REALM_CREATE,
-        REALM_DESTROY, SUCCESS,
+        ERROR_INPUT, GRANULE_UNDELEGATE, REALM_ACTIVATE, REALM_CREATE, REALM_DESTROY, SUCCESS,
     };
     use crate::test_utils::*;
 
@@ -175,27 +173,7 @@ mod test {
 
     #[test]
     fn rmi_realm_create_positive() {
-        for mocking_addr in &[granule_addr(0), granule_addr(1)] {
-            let ret = rmi::<GRANULE_DELEGATE>(&[*mocking_addr]);
-            assert_eq!(ret[0], SUCCESS);
-        }
-
-        let (rd, rtt, params_ptr) = (granule_addr(0), granule_addr(1), granule_addr(2));
-
-        unsafe {
-            let params = &mut *(params_ptr as *mut Params);
-            params.s2sz = 40;
-            params.rtt_num_start = 1;
-            params.rtt_level_start = 0;
-            params.rtt_base = rtt as u64;
-        };
-
-        let ret = rmi::<REALM_CREATE>(&[rd, params_ptr]);
-        assert_eq!(ret[0], SUCCESS);
-        unsafe {
-            let rd_obj = &*(rd as *const Rd);
-            assert!(rd_obj.at_state(State::New));
-        };
+        let rd = realm_create();
 
         let ret = rmi::<REALM_ACTIVATE>(&[rd]);
         assert_eq!(ret[0], SUCCESS);

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -181,6 +181,8 @@ mod test {
         };
 
         realm_destroy(rd);
+
+        miri_teardown();
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -183,13 +183,7 @@ mod test {
             assert!(rd_obj.at_state(State::Active));
         };
 
-        let ret = rmi::<REALM_DESTROY>(&[rd]);
-        assert_eq!(ret[0], SUCCESS);
-
-        for mocking_addr in &[granule_addr(0), granule_addr(1)] {
-            let ret = rmi::<GRANULE_UNDELEGATE>(&[*mocking_addr]);
-            assert_eq!(ret[0], SUCCESS);
-        }
+        realm_destroy(rd);
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -163,9 +163,7 @@ fn create_realm(vmid: usize) -> Result<(), Error> {
 #[cfg(test)]
 mod test {
     use crate::realm::rd::{Rd, State};
-    use crate::rmi::{
-        ERROR_INPUT, GRANULE_UNDELEGATE, REALM_ACTIVATE, REALM_CREATE, REALM_DESTROY, SUCCESS,
-    };
+    use crate::rmi::{ERROR_INPUT, REALM_ACTIVATE, REALM_CREATE, SUCCESS};
     use crate::test_utils::*;
 
     use alloc::vec;

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -162,7 +162,6 @@ fn create_realm(vmid: usize) -> Result<(), Error> {
 
 #[cfg(test)]
 mod test {
-    use crate::granule::array::granule_addr;
     use crate::realm::rd::{Rd, State};
     use crate::rmi::{
         ERROR_INPUT, GRANULE_UNDELEGATE, REALM_ACTIVATE, REALM_CREATE, REALM_DESTROY, SUCCESS,

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -105,6 +105,7 @@ impl Params {
     }
 
     pub fn verify_compliance(&self, rd: usize) -> Result<(), Error> {
+        trace!("{:?}", self);
         if self.rtt_base as usize == rd {
             return Err(Error::RmiErrorInput);
         }

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -105,7 +105,6 @@ impl Params {
     }
 
     pub fn verify_compliance(&self, rd: usize) -> Result<(), Error> {
-        trace!("{:?}", self);
         if self.rtt_base as usize == rd {
             return Err(Error::RmiErrorInput);
         }

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -276,7 +276,7 @@ mod test {
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
     // Test Case: cmd_rec_create
-    // Covered RMIs: REC_CREATE, REC_DESTROY
+    // Covered RMIs: REC_CREATE, REC_DESTROY, REC_AUX_COUNT
     // Related Spec: D1.2.4 REC creation flow
     #[test]
     fn rmi_rec_create_positive() {

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -272,11 +272,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
 #[cfg(test)]
 mod test {
-    use crate::realm::rd::{Rd, State};
-    use crate::rmi::{ERROR_INPUT, MAX_REC_AUX_GRANULES, REC_AUX_COUNT, SUCCESS};
     use crate::test_utils::*;
-
-    use alloc::vec;
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
     // Test Case: cmd_rec_create

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -241,19 +241,9 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
 
             #[cfg(any(miri, test))]
             {
-                // specialized
-                /*
-                use crate::rsi::PSCI_CPU_ON;
-                use crate::event::realmexit::RecExitReason;
-                let reason: u64 = RecExitReason::PSCI.into();
-
-                rec.set_psci_pending(true);
-                run.set_exit_reason(reason as u8);
-                run.set_gpr(0, PSCI_CPU_ON as u64).unwrap();
-
-                set_reg(&mut rec, 1, 1).unwrap();*/
                 use crate::test_utils::mock;
                 mock::realm::setup_psci_complete(&mut rec, &mut run);
+                mock::realm::setup_ripas_state(&mut rec, &mut run);
             }
 
             rec.set_state(RecState::Ready);

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -269,3 +269,24 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         complete_psci(&mut caller, &mut target, status)
     });
 }
+
+#[cfg(test)]
+mod test {
+    use crate::realm::rd::{Rd, State};
+    use crate::rmi::{ERROR_INPUT, MAX_REC_AUX_GRANULES, REC_AUX_COUNT, SUCCESS};
+    use crate::test_utils::*;
+
+    use alloc::vec;
+
+    // Source: https://github.com/ARM-software/cca-rmm-acs
+    // Test Case: cmd_rec_create
+    // Covered RMIs: REC_CREATE, REC_DESTROY
+    // Related Spec: D1.2.4 REC creation flow
+    #[test]
+    fn rmi_rec_create_positive() {
+        let rd = realm_create();
+        let rec = rec_create(rd);
+        rec_destroy(rec);
+        realm_destroy(rd);
+    }
+}

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -306,6 +306,8 @@ mod test {
         rec_create(rd, IDX_REC1, IDX_REC1_PARAMS, IDX_REC1_AUX);
         rec_destroy(IDX_REC1, IDX_REC1_AUX);
         realm_destroy(rd);
+
+        miri_teardown();
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
@@ -332,5 +334,7 @@ mod test {
         assert_eq!(ret[0], SUCCESS);
 
         mock::host::realm_teardown(rd);
+
+        miri_teardown();
     }
 }

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -153,6 +153,13 @@ impl Run {
         }
         Ok(self.exit.gprs[idx])
     }
+
+    pub fn ripas(&self) -> (u64, u64) {
+        (
+            self.exit.ripas_base,
+            self.exit.ripas_base + self.exit.ripas_size,
+        )
+    }
 }
 
 impl core::fmt::Debug for Run {

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -141,6 +141,18 @@ impl Run {
     pub fn set_cntp_cval(&mut self, val: u64) {
         self.exit.cntp_cval = val;
     }
+
+    pub fn exit_reason(&self) -> u8 {
+        self.exit.exit_reason
+    }
+
+    pub fn gpr(&self, idx: usize) -> Result<u64, Error> {
+        if idx >= NR_GPRS {
+            error!("out of index: {}", idx);
+            return Err(Error::RmiErrorInput);
+        }
+        Ok(self.exit.gprs[idx])
+    }
 }
 
 impl core::fmt::Debug for Run {

--- a/rmm/src/rmi/rec/vtcr.rs
+++ b/rmm/src/rmi/rec/vtcr.rs
@@ -5,7 +5,13 @@ use crate::rmi::error::Error;
 use aarch64_cpu::registers::*;
 
 fn is_feat_vmid16_present() -> bool {
-    ID_AA64MMFR1_EL1.read(ID_AA64MMFR1_EL1::VMIDBits) == ID_AA64MMFR1_EL1::VMIDBits::Bits16.into()
+    #[cfg(not(any(miri, test)))]
+    let ret = ID_AA64MMFR1_EL1.read(ID_AA64MMFR1_EL1::VMIDBits)
+        == ID_AA64MMFR1_EL1::VMIDBits::Bits16.into();
+
+    #[cfg(any(miri, test))]
+    let ret = true;
+    ret
 }
 
 pub fn prepare_vtcr(rd: &Rd) -> Result<u64, Error> {

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -134,6 +134,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         if !is_granule_aligned(base)
             || !is_granule_aligned(top)
             || !rd.addr_in_par(base)
+            || top.checked_sub(GRANULE_SIZE).is_none()
             || !rd.addr_in_par(top - GRANULE_SIZE)
         // overflow detected!
         {

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -427,6 +427,8 @@ mod test {
         }
 
         realm_destroy(rd);
+
+        miri_teardown();
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
@@ -455,6 +457,8 @@ mod test {
         mock::host::unmap(rd, ipa, false);
 
         realm_destroy(rd);
+
+        miri_teardown();
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
@@ -489,6 +493,8 @@ mod test {
         mock::host::unmap(rd, ipa, false);
 
         realm_destroy(rd);
+
+        miri_teardown();
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
@@ -582,6 +588,8 @@ mod test {
         }
 
         realm_destroy(rd);
+
+        miri_teardown();
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
@@ -629,6 +637,8 @@ mod test {
         mock::host::unmap(rd, ipa, true);
 
         realm_destroy(rd);
+
+        miri_teardown();
     }
 
     // Source: https://github.com/ARM-software/cca-rmm-acs
@@ -659,5 +669,7 @@ mod test {
 
         mock::host::unmap(rd, ipa, false);
         mock::host::realm_teardown(rd);
+
+        miri_teardown();
     }
 }

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -353,3 +353,52 @@ pub fn validate_ipa(rd: &Rd, ipa: usize) -> Result<(), Error> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use crate::granule::array::granule_addr;
+    use crate::rmi::{GRANULE_DELEGATE, RTT_CREATE, SUCCESS};
+    use crate::test_utils::*; // alloc_granule
+
+    // Source: https://github.com/ARM-software/cca-rmm-acs
+    // Test Case: cmd_rtt_create
+    #[test]
+    fn rmi_rtt_create_positive() {
+        let rd = realm_create();
+        let mut ipa: usize = 0x0;
+        let mut level: usize = 0x1;
+
+        for mocking_addr in &[
+            granule_addr(3),
+            granule_addr(4),
+            granule_addr(5),
+            granule_addr(6),
+        ] {
+            let ret = rmi::<GRANULE_DELEGATE>(&[*mocking_addr]);
+            assert_eq!(ret[0], SUCCESS);
+        }
+
+        let (rtt1, rtt2, rtt3, rtt4) = (
+            granule_addr(3),
+            granule_addr(4),
+            granule_addr(5),
+            granule_addr(6),
+        );
+
+        let ret = rmi::<RTT_CREATE>(&[rd, rtt1, ipa, level]);
+        assert_eq!(ret[0], SUCCESS);
+
+        level = 0x2;
+        let ret = rmi::<RTT_CREATE>(&[rd, rtt2, ipa, level]);
+        assert_eq!(ret[0], SUCCESS);
+
+        level = 0x3;
+        let ret = rmi::<RTT_CREATE>(&[rd, rtt3, ipa, level]);
+        assert_eq!(ret[0], SUCCESS);
+
+        ipa = 0x40000000;
+        level = 0x2;
+        let ret = rmi::<RTT_CREATE>(&[rd, rtt4, ipa, level]);
+        assert_eq!(ret[0], SUCCESS);
+    }
+}

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -136,7 +136,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             || !rd.addr_in_par(base)
             || top.checked_sub(GRANULE_SIZE).is_none()
             || !rd.addr_in_par(top - GRANULE_SIZE)
-        // overflow detected!
         {
             return Err(Error::RmiErrorInput);
         }
@@ -373,10 +372,10 @@ mod test {
         let rd = realm_create();
 
         let (rtt1, rtt2, rtt3, rtt4) = (
-            alloc_granule(3),
-            alloc_granule(4),
-            alloc_granule(5),
-            alloc_granule(6),
+            mock::host::alloc_granule(IDX_RTT_LEVEL1),
+            mock::host::alloc_granule(IDX_RTT_LEVEL2),
+            mock::host::alloc_granule(IDX_RTT_LEVEL3),
+            mock::host::alloc_granule(IDX_RTT_OTHER),
         );
 
         for rtt in &[rtt1, rtt2, rtt3, rtt4] {
@@ -398,7 +397,7 @@ mod test {
 
         // This seems that it should be a failure condition
         unsafe {
-            let mut rd_obj = &mut *(rd as *mut Rd);
+            let rd_obj = &mut *(rd as *mut Rd);
             rd_obj.set_state(State::SystemOff);
             assert!(rd_obj.at_state(State::SystemOff));
         };
@@ -474,7 +473,7 @@ mod test {
 
         let ipa = IPA_ADDR_UNPROTECTED_UNASSIGNED;
         let level = MAP_LEVEL;
-        let ns = alloc_granule(IDX_NS_DESC);
+        let ns = mock::host::alloc_granule(IDX_NS_DESC);
         let desc = ns | ATTR_NORMAL_WB_WA_RA | ATTR_STAGE2_AP_RW | ATTR_INNER_SHARED;
 
         let ret = rmi::<RTT_MAP_UNPROTECTED>(&[rd, ipa, level, desc]);
@@ -534,7 +533,7 @@ mod test {
         assert_eq!(ripas, RMI_DESTROYED);
 
         // Check for RIPAS transition from ASSIGNED,DESTROYED
-        let data = alloc_granule(IDX_DATA3);
+        let data = mock::host::alloc_granule(IDX_DATA3);
         let ret = rmi::<GRANULE_DELEGATE>(&[data]);
         assert_eq!(ret[0], SUCCESS);
 
@@ -558,7 +557,7 @@ mod test {
 
         mock::host::map(rd, ipa);
 
-        let data = alloc_granule(IDX_DATA4);
+        let data = mock::host::alloc_granule(IDX_DATA4);
         let ret = rmi::<GRANULE_DELEGATE>(&[data]);
         assert_eq!(ret[0], SUCCESS);
 
@@ -647,7 +646,6 @@ mod test {
     // Covered RMIs: RTT_SET_RIPAS
     #[test]
     fn rmi_rtt_set_ripas_positive() {
-        use crate::event::realmexit::RecExitReason;
         use crate::rmi::rec::run::Run;
         use crate::rsi::PSCI_CPU_ON;
 

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -385,8 +385,22 @@ mod test {
             granule_addr(6),
         );
 
+        use crate::realm::rd::{Rd, State};
+
+        unsafe {
+            let rd_obj = &*(rd as *const Rd);
+            assert!(rd_obj.at_state(State::New));
+        };
+
         let ret = rmi::<RTT_CREATE>(&[rd, rtt1, ipa, level]);
         assert_eq!(ret[0], SUCCESS);
+
+        // This seems that it should be a failure condition
+        unsafe {
+            let mut rd_obj = &mut *(rd as *mut Rd);
+            rd_obj.set_state(State::SystemOff);
+            assert!(rd_obj.at_state(State::SystemOff));
+        };
 
         level = 0x2;
         let ret = rmi::<RTT_CREATE>(&[rd, rtt2, ipa, level]);

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -356,13 +356,12 @@ pub fn validate_ipa(rd: &Rd, ipa: usize) -> Result<(), Error> {
 
 #[cfg(test)]
 mod test {
-    use crate::granule::array::granule_addr;
     use crate::realm::rd::{Rd, State};
     use crate::rmi::{
         GRANULE_DELEGATE, GRANULE_UNDELEGATE, RTT_CREATE, RTT_DESTROY, RTT_INIT_RIPAS,
         RTT_READ_ENTRY, SUCCESS,
     };
-    use crate::test_utils::*; // alloc_granule
+    use crate::test_utils::*;
 
     use alloc::vec;
 
@@ -374,10 +373,10 @@ mod test {
         let rd = realm_create();
 
         let (rtt1, rtt2, rtt3, rtt4) = (
-            granule_addr(3),
-            granule_addr(4),
-            granule_addr(5),
-            granule_addr(6),
+            alloc_granule(3),
+            alloc_granule(4),
+            alloc_granule(5),
+            alloc_granule(6),
         );
 
         for rtt in &[rtt1, rtt2, rtt3, rtt4] {
@@ -438,7 +437,7 @@ mod test {
     fn rmi_rtt_init_ripas_positive() {
         let rd = realm_create();
 
-        let (rtt1, rtt2, rtt3) = (granule_addr(3), granule_addr(4), granule_addr(5));
+        let (rtt1, rtt2, rtt3) = (alloc_granule(3), alloc_granule(4), alloc_granule(5));
 
         for rtt in &[rtt1, rtt2, rtt3] {
             let ret = rmi::<GRANULE_DELEGATE>(&[*rtt]);

--- a/rmm/src/test_utils.rs
+++ b/rmm/src/test_utils.rs
@@ -3,7 +3,7 @@ use crate::event::Mainloop;
 use crate::granule::array::granule_addr; // alloc_granule
 use crate::monitor::Monitor;
 use crate::rmi::realm::Params;
-use crate::rmi::{GRANULE_DELEGATE, REALM_CREATE, SUCCESS};
+use crate::rmi::{GRANULE_DELEGATE, GRANULE_UNDELEGATE, REALM_CREATE, REALM_DESTROY, SUCCESS};
 
 use alloc::vec::Vec;
 
@@ -55,4 +55,14 @@ pub fn realm_create() -> usize {
     assert_eq!(ret[0], SUCCESS);
 
     rd
+}
+
+pub fn realm_destroy(rd: usize) {
+    let ret = rmi::<REALM_DESTROY>(&[rd]);
+    assert_eq!(ret[0], SUCCESS);
+
+    for mocking_addr in &[granule_addr(0), granule_addr(1)] {
+        let ret = rmi::<GRANULE_UNDELEGATE>(&[*mocking_addr]);
+        assert_eq!(ret[0], SUCCESS);
+    }
 }

--- a/rmm/src/test_utils.rs
+++ b/rmm/src/test_utils.rs
@@ -302,5 +302,14 @@ pub mod mock {
             let target_mpidr = IDX_REC2 % IDX_REC1;
             set_reg(rec, 1, target_mpidr).unwrap();
         }
+
+        pub fn setup_ripas_state(rec: &mut Rec<'_>, run: &mut Run) {
+            let ipa_base: u64 = 0;
+            let ipa_top: u64 = 0x1000;
+            const RSI_RAM: u8 = 1;
+            const RSI_NO_CHANGE_DESTROYED: u64 = 0;
+            run.set_ripas(ipa_base, ipa_top, RSI_RAM);
+            rec.set_ripas(ipa_base, ipa_top, RSI_RAM, RSI_NO_CHANGE_DESTROYED);
+        }
     }
 }

--- a/rmm/src/test_utils.rs
+++ b/rmm/src/test_utils.rs
@@ -196,6 +196,27 @@ pub const ATTR_NORMAL_WB_WA_RA: usize = 1 << 2;
 pub const ATTR_STAGE2_AP_RW: usize = 3 << 6;
 pub const ATTR_INNER_SHARED: usize = 3 << 8;
 
+/// This function is a temporary workaround to pass the MIRI test due to a memory leak bug
+/// related to the RMM Page Table. It forces the RMM Page Table to drop at the end of the
+/// test, preventing the memory leak issue from occurring during MIRI testing.
+///
+/// - Memory Leak in RMM Page Table: During the mapping/unmapping process, the Page Table
+///   might not deallocate even when there are no entries in Level 1-3 tables.
+///
+/// Note: When testing this function individually, set `TEST_TOTAL` to 1.
+pub fn miri_teardown() {
+    use core::sync::atomic::AtomicUsize;
+    use core::sync::atomic::Ordering;
+
+    const TEST_TOTAL: usize = 11;
+    static TEST_COUNT: AtomicUsize = AtomicUsize::new(0);
+    TEST_COUNT.fetch_add(1, Ordering::SeqCst);
+
+    if TEST_COUNT.load(Ordering::SeqCst) == TEST_TOTAL {
+        crate::mm::translation::drop_page_table();
+    }
+}
+
 pub mod mock {
     pub mod host {
         use super::super::*;

--- a/rmm/src/test_utils.rs
+++ b/rmm/src/test_utils.rs
@@ -2,8 +2,10 @@ use crate::event::Context;
 use crate::event::Mainloop;
 use crate::granule::{GRANULE_REGION, GRANULE_SIZE};
 use crate::monitor::Monitor;
-use crate::rmi::realm::Params;
+use crate::rmi::realm::Params as RealmParams;
+use crate::rmi::rec::params::Params as RecParams;
 use crate::rmi::{GRANULE_DELEGATE, GRANULE_UNDELEGATE, REALM_CREATE, REALM_DESTROY, SUCCESS};
+use crate::rmi::{MAX_REC_AUX_GRANULES, REC_AUX_COUNT, REC_CREATE, REC_DESTROY};
 use crate::{get_granule, get_granule_if};
 
 use alloc::vec::Vec;
@@ -43,7 +45,7 @@ pub fn realm_create() -> usize {
     let (rd, rtt, params_ptr) = (alloc_granule(0), alloc_granule(1), alloc_granule(2));
 
     unsafe {
-        let params = &mut *(params_ptr as *mut Params);
+        let params = &mut *(params_ptr as *mut RealmParams);
         params.s2sz = 40;
         params.rtt_num_start = 1;
         params.rtt_level_start = 0;
@@ -66,6 +68,52 @@ pub fn realm_destroy(rd: usize) {
     }
 }
 
+pub fn rec_create(rd: usize) -> usize {
+    let (rec, params_ptr) = (alloc_granule(IDX_REC), alloc_granule(IDX_REC_PARAMS));
+    let ret = rmi::<GRANULE_DELEGATE>(&[rec]);
+    assert_eq!(ret[0], SUCCESS);
+
+    let ret = rmi::<REC_AUX_COUNT>(&[rd]);
+    assert_eq!(ret[0], SUCCESS);
+    assert_eq!(ret[1], MAX_REC_AUX_GRANULES);
+
+    let aux_count = ret[1];
+    unsafe {
+        let params = &mut *(params_ptr as *mut RecParams);
+        params.pc = 0;
+        params.flags = 1; // RMI_RUNNABLE
+        params.mpidr = 0; // MPIDR_VALID
+        params.num_aux = aux_count as u64;
+
+        for idx in 0..aux_count {
+            let mocking_addr = alloc_granule(idx + IDX_REC_AUX);
+            let ret = rmi::<GRANULE_DELEGATE>(&[mocking_addr]);
+            assert_eq!(ret[0], SUCCESS);
+
+            params.aux[idx] = mocking_addr as u64;
+        }
+    }
+
+    let ret = rmi::<REC_CREATE>(&[rd, rec, params_ptr]);
+    assert_eq!(ret[0], SUCCESS);
+
+    rec
+}
+
+pub fn rec_destroy(rec: usize) {
+    let ret = rmi::<REC_DESTROY>(&[rec]);
+    assert_eq!(ret[0], SUCCESS);
+
+    let ret = rmi::<GRANULE_UNDELEGATE>(&[rec]);
+    assert_eq!(ret[0], SUCCESS);
+
+    for idx in 0..MAX_REC_AUX_GRANULES {
+        let mocking_addr = alloc_granule(idx + IDX_REC_AUX);
+        let ret = rmi::<GRANULE_UNDELEGATE>(&[mocking_addr]);
+        assert_eq!(ret[0], SUCCESS);
+    }
+}
+
 pub fn align_up(addr: usize) -> usize {
     let align_mask = GRANULE_SIZE - 1;
     if addr & align_mask == 0 {
@@ -75,6 +123,21 @@ pub fn align_up(addr: usize) -> usize {
     }
 }
 
+/*
+ * 0: RD
+ * 1: RTT0
+ * 2: Realm Params
+ * 3: RTT1
+ * 4: RTT2
+ * 5: RTT3
+ * 6: RTT4
+ * 7: REC
+ * 8: REC Params
+ * 9..25: REC AUX
+ */
+const IDX_REC: usize = 7;
+const IDX_REC_PARAMS: usize = 8;
+const IDX_REC_AUX: usize = 9;
 pub fn alloc_granule(idx: usize) -> usize {
     let start = unsafe { GRANULE_REGION.as_ptr() as usize };
     let first = crate::test_utils::align_up(start);

--- a/rmm/src/test_utils.rs
+++ b/rmm/src/test_utils.rs
@@ -240,10 +240,12 @@ pub mod mock {
             }
         }
 
-        pub fn unmap(rd: usize, ipa: usize) {
-            let ipa_aligned = (ipa / L2_SIZE) * L2_SIZE;
-            let ret = rmi::<RTT_DESTROY>(&[rd, ipa_aligned, 3]);
-            assert_eq!(ret[0], SUCCESS);
+        pub fn unmap(rd: usize, ipa: usize, folded: bool) {
+            if !folded {
+                let ipa_aligned = (ipa / L2_SIZE) * L2_SIZE;
+                let ret = rmi::<RTT_DESTROY>(&[rd, ipa_aligned, 3]);
+                assert_eq!(ret[0], SUCCESS);
+            }
 
             let ipa_aligned = (ipa / L1_SIZE) * L1_SIZE;
             let ret = rmi::<RTT_DESTROY>(&[rd, ipa_aligned, 2]);

--- a/rmm/src/test_utils.rs
+++ b/rmm/src/test_utils.rs
@@ -1,6 +1,10 @@
 use crate::event::Context;
 use crate::event::Mainloop;
+use crate::granule::array::granule_addr; // alloc_granule
 use crate::monitor::Monitor;
+use crate::rmi::realm::Params;
+use crate::rmi::{GRANULE_DELEGATE, REALM_CREATE, SUCCESS};
+
 use alloc::vec::Vec;
 
 pub fn rmi<const COMMAND: usize>(arg: &[usize]) -> Vec<usize> {
@@ -27,4 +31,28 @@ pub fn extract_bits(value: usize, start: u32, end: u32) -> usize {
         (1 << num_bits) - 1
     };
     (value >> start) & mask
+}
+
+use crate::{get_granule, get_granule_if};
+
+pub fn realm_create() -> usize {
+    for mocking_addr in &[granule_addr(0), granule_addr(1)] {
+        let ret = rmi::<GRANULE_DELEGATE>(&[*mocking_addr]);
+        assert_eq!(ret[0], SUCCESS);
+    }
+
+    let (rd, rtt, params_ptr) = (granule_addr(0), granule_addr(1), granule_addr(2));
+
+    unsafe {
+        let params = &mut *(params_ptr as *mut Params);
+        params.s2sz = 40;
+        params.rtt_num_start = 1;
+        params.rtt_level_start = 0;
+        params.rtt_base = rtt as u64;
+    };
+
+    let ret = rmi::<REALM_CREATE>(&[rd, params_ptr]);
+    assert_eq!(ret[0], SUCCESS);
+
+    rd
 }

--- a/scripts/tests/crates.sh
+++ b/scripts/tests/crates.sh
@@ -5,7 +5,9 @@ ROOT=$(git rev-parse --show-toplevel)
 mkdir -p $ROOT/out
 
 cd $ROOT/rmm
-cross test --target=aarch64-unknown-linux-gnu --lib -- --test-threads=1
+cross test $1 \
+	--target=aarch64-unknown-linux-gnu \
+	--lib -- --test-threads=1 --nocapture
 
 if [ $? -ne 0 ]; then
 	exit 1

--- a/scripts/tests/miri.sh
+++ b/scripts/tests/miri.sh
@@ -6,7 +6,24 @@ mkdir -p $ROOT/out
 
 cd $ROOT/rmm
 
-MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test --target aarch64-unknown-linux-gnu
+# rmi::features::test::rmi_features
+# rmi::gpt::test::rmi_granule_delegate_negative
+# rmi::gpt::test::rmi_granule_delegate_positive
+# rmi::gpt::test::rmi_granule_undelegate
+# rmi::realm::test::rmi_realm_create_negative
+# rmi::realm::test::rmi_realm_create_positive
+# rmi::version::test::rmi_version
+if [ $# -eq 0 ]; then
+	MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test \
+		rmi::features::test::rmi_features \
+		--target aarch64-unknown-linux-gnu -- --nocapture
+	MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test \
+		rmi::version::test::rmi_version \
+		--target aarch64-unknown-linux-gnu -- --nocapture
+else
+	MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test $1 \
+		--target aarch64-unknown-linux-gnu -- --nocapture
+fi
 
 if [ $? -ne 0 ]; then
 	exit 1

--- a/scripts/tests/miri.sh
+++ b/scripts/tests/miri.sh
@@ -6,24 +6,8 @@ mkdir -p $ROOT/out
 
 cd $ROOT/rmm
 
-# rmi::features::test::rmi_features
-# rmi::gpt::test::rmi_granule_delegate_negative
-# rmi::gpt::test::rmi_granule_delegate_positive
-# rmi::gpt::test::rmi_granule_undelegate
-# rmi::realm::test::rmi_realm_create_negative
-# rmi::realm::test::rmi_realm_create_positive
-# rmi::version::test::rmi_version
-if [ $# -eq 0 ]; then
-	MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test \
-		rmi::features::test::rmi_features \
-		--target aarch64-unknown-linux-gnu -- --nocapture
-	MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test \
-		rmi::version::test::rmi_version \
-		--target aarch64-unknown-linux-gnu -- --nocapture
-else
-	MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test $1 \
-		--target aarch64-unknown-linux-gnu -- --nocapture
-fi
+RUSTFLAGS="-Awarnings" MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test $1 \
+	--target aarch64-unknown-linux-gnu -- --nocapture
 
 if [ $? -ne 0 ]; then
 	exit 1


### PR DESCRIPTION
This PR aims to introduce MIRI testing across all RMI functions to strengthen memory safety within RMM, particularly by addressing potential issues arising from `unsafe code`.

To cover all 23 RMI types, 11 new test cases (TCs) have been added (_see Appendix: MIRI Test Cases for details_), leading to the **discovery of 2 bugs** (1 memory leak, 1 integer overflow). Additionally, while writing the MIRI test cases, a manual review revealed a misalignment within the RMM specification, which was reported to Arm.

## How to run
```sh
 $ ./scripts/tests/miri.sh
running 22 tests
test r#macro::test::eprintln_with_format ... ok
test r#macro::test::eprintln_without_arg ... ok
test r#macro::test::eprintln_without_format ... ok
test r#macro::test::println_with_format ... ok
test r#macro::test::println_without_arg ... ok
test r#macro::test::println_without_format ... ok
test r#macro::test::set_of_const_assert ... ok
test rmi::features::test::rmi_features ... ok
test rmi::gpt::test::rmi_granule_delegate_negative ... ok
test rmi::gpt::test::rmi_granule_delegate_positive ... ok
test rmi::gpt::test::rmi_granule_undelegate ... ok
test rmi::realm::test::rmi_realm_create_negative ... ok
test rmi::realm::test::rmi_realm_create_positive ... ok
test rmi::rec::handlers::test::rmi_rec_create_positive ... ok
test rmi::rec::handlers::test::rmi_rec_enter_positive ... ok
test rmi::rtt::test::rmi_data_create_positive ... ok
test rmi::rtt::test::rmi_rtt_create_positive ... ok
test rmi::rtt::test::rmi_rtt_fold_positive ... ok
test rmi::rtt::test::rmi_rtt_init_ripas_positive ... ok
test rmi::rtt::test::rmi_rtt_map_unprotected_positive ... ok
test rmi::rtt::test::rmi_rtt_set_ripas_positive ... ok
test rmi::version::test::rmi_version ... ok

test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 144.88s
```

## Discovered Bugs
### Bug 1: Memory Leak in the RMM Page Table
- **Bug Type**: Memory Leak
- **Cause**: During the process of mapping/unmapping the RMM page table, level 1-3 sub-tables were not released even when they contained no entries.
- **Temporary Solution**: As a temporary measure, the RMM page table is dropped upon completion of the MIRI test.
- **Future Discussion**: Creating and destroying sub-tables in the RMM page table with each GRANULE_DELEGATE call may result in performance degradation. It is necessary to find a solution that addresses the memory leak while minimizing performance impacts.
- **Note**: The RMM page table is managed as a static variable, and in Rust, the `drop()` function for static variables is not invoked. As a result, sub-tables used by RMM continue to allocate memory without being released.

```sh
$ cargo miri test rmi::gpt::test::rmi_granule_delegate

error: memory leaked: alloc56894755 (Rust heap, size: 4096, align: 4096), allocated here:
   --> /home/sangwan/.rustup/toolchains/nightly-2024-04-21-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:100:9
    |
100 |         __rust_alloc(layout.size(), layout.align())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: BACKTRACE:
    = note: inside `alloc::alloc::alloc` at /home/sangwan/.rustup/toolchains/nightly-2024-04-21-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/alloc.rs:100:9: 100:52
    = note: inside `<vmsa::page_table::DefaultMemAlloc as vmsa::page_table::MemAlloc>::allocate` at /home/sangwan/islet/lib/vmsa/src/page_table.rs:63:9: 63:36
    = note: inside `vmsa::page_table::PageTable::<vmsa::address::VirtAddr, mm::page_table::L3Table, mm::page_table::entry::Entry, 512>::new_in` at /home/sangwan/islet/lib/vmsa/src/page_table.rs:159:13: 159:92
    = note: inside `<vmsa::page_table::PageTable<vmsa::address::VirtAddr, mm::page_table::L2Table, mm::page_table::entry::Entry, 512> as vmsa::page_table::PageTableMethods<vmsa::address::VirtAddr, mm::page_table::L2Table, mm::page_table::entry::Entry, 512>>::set_page::<mm::page::BasePageSize>` at /home/sangwan/islet/lib/vmsa/src/page_table.rs:392:25: 394:26
    = note: inside `<vmsa::page_table::PageTable<vmsa::address::VirtAddr, mm::page_table::L1Table, mm::page_table::entry::Entry, 512> as vmsa::page_table::PageTableMethods<vmsa::address::VirtAddr, mm::page_table::L1Table, mm::page_table::entry::Entry, 512>>::set_page::<mm::page::BasePageSize>` at /home/sangwan/islet/lib/vmsa/src/page_table.rs:400:13: 400:50
    = note: inside `<vmsa::page_table::PageTable<vmsa::address::VirtAddr, mm::page_table::L1Table, mm::page_table::entry::Entry, 512> as vmsa::page_table::PageTableMethods<vmsa::address::VirtAddr, mm::page_table::L1Table, mm::page_table::entry::Entry, 512>>::set_pages::<mm::page::BasePageSize>` at /home/sangwan/islet/lib/vmsa/src/page_table.rs:215:19: 215:
```

### Bug 2: Integer Overflow in RMI_RTT_SET_RIPAS
- **Bug Type**: Integer Overflow
- **Cause**: An overflow occurs when the `top` in `RMI_RTT_SET_RIPAS` is smaller than `GRANULE_SIZE`.
- **Solution**: Implemented an overflow check and return an appropriate error when detected.

```sh
note: inside closure
   --> rmm/src/rmi/rtt.rs:649:36
    |
648 |     #[test]
    |     ------- in this procedural macro expansion
649 |     fn rmi_rtt_set_ripas_positive() {
    |                                    ^
    = note: this warning originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

thread 'rmi::rtt::test::rmi_rtt_set_ripas_positive' panicked at rmm/src/rmi/rtt.rs:138:32:
attempt to subtract with overflow
```
## Spec Feedback: Ensuring realm_state validation in B4.3.15

It seems necessary to review between B4.3.15 and D1.2.2 for spec consistency.

1. Specification Restrictions
According to "D1.2.2 Realm Translation Table creation flow" subsequent levels of RTT
can be created when the state of the Realm is REALM_NEW or REALM_ACTIVATE.

> D1.2.2 Realm Translation Table creation flow
> Subsequent levels of RTT are added using the RMI_RTT_CREATE command.
> This can be performed when the state of the Realm is REALM_NEW or REALM_ACTIVE.

2. Missing Failure Conditions
However in "B4.3.15 RMI_RTT_CREATE", the condition to check the realm_state is missing.

3. Suggestion
It would be necessary either to add this realm_state validation within "B4.3.15.2 Failure conditions"
or to clarify the details in D1.2.2 for better alignment.

## Process of Applying MIRI Test
1. Extract inputs and outputs of the RMI to be tested from positive test cases in the ACS tests.
2. Write the MIRI test.
3. Execute the MIRI test.
4. Implement mocking for parts requiring simulation.
5. Apply patches for any bugs encountered.

## Challenges in Applying MIRI

### Handling Provenance Issues with Host-Provided Memory
- **Problem**: When using MIRI to test Rust code, "No provenance" errors may occur 1) during operations like `core::ptr::write` or 2) when converting externally allocated memory into specific Rust objects. This is because the memory addresses, not allocated by RMM, lack the required provenance that MIRI enforces.
- **Limitation**: Currently, MIRI does not allow the disabling of provenance checks. Additionally, Rust does not natively support allocating memory at specific addresses, complicating this scenario further.
- **Proposed Alternative**: Instead of using externally provided memory addresses directly, simulate these addresses by allocating memory within RMM’s managed space and treat it as if it were external memory. This approach avoids provenance issues while allowing MIRI testing.

### Realm Simulation
- **Problem**: MIRI cannot execute assembly code, making it impossible to directly enter the realm context.
- **Solution**: Write mocking for the necessary parts, simulating the execution of the realm and the invocation of RSI as if it were happening in the test.

## Remaining Works
1. **Enable Stacked Borrows Check**: Currently, the MIRI rule for "Stacked Borrows" is disabled as it is experimental. Plan to enable this check.
2. **Add Negative Test Cases**: In addition to the positive test cases, add negative test cases to ensure more comprehensive testing.

## Appendix: MIRI Test Cases
| Index | Command                   | Test Case                                        | Test Result | Note                                           |
| ----- | ------------------------- | ------------------------------------------------ | ----------- | ---------------------------------------------- |
| 1     | RMI_VERSION               | rmi::version::test::rmi_version                  | PASS        |                                                |
| 2     | RMI_GRANULE_DELEGATE      | rmi::gpt::test::rmi_granule_delegate_positive    | PASS        | Bug Found: Memory Leak in RMM Page Table       |
| 3     | RMI_GRANULE_UNDELEGATE    | rmi::gpt::test::rmi_granule_delegate_positive    | PASS        |                                                |
| 4     | RMI_DATA_CREATE           | rmi::rtt::test::rmi_data_create_positive         | PASS        |                                                |
| 5     | RMI_DATA_CREATE_UNKNOWN   | rmi::rtt::test::rmi_data_create_positive         | PASS        |                                                |
| 6     | RMI_DATA_DESTROY          | rmi::rtt::test::rmi_data_create_positive         | PASS        |                                                |
| 7     | RMI_REALM_ACTIVATE        | rmi::realm::test::rmi_realm_create_positive      | PASS        |                                                |
| 8     | RMI_REALM_CREATE          | rmi::realm::test::rmi_realm_create_positive      | PASS        |                                                |
| 9     | RMI_REALM_DESTROY         | rmi::realm::test::rmi_realm_create_positive      | PASS        |                                                |
| 10    | RMI_REC_CREATE            | rmi::realm::test::rmi_rec_create_positive        | PASS        |                                                |
| 11    | RMI_REC_DESTROY           | rmi::realm::test::rmi_rec_create_positive        | PASS        |                                                |
| 12    | RMI_REC_ENTER             | rmi::rec::handlers::test::rmi_rec_enter_positive | PASS        |                                                |
| 13    | RMI_RTT_CREATE            | rmi::realm::test::rmi_rtt_create_positive        | PASS        | Spec Feedback: Misalignment in the realm state |
| 14    | RMI_RTT_DESTROY           | rmi::realm::test::rmi_rtt_create_positive        | PASS        |                                                |
| 15    | RMI_RTT_MAP_UNPROTECTED   | rmi::rtt::test::rmi_rtt_map_unprotected_positive | PASS        |                                                |
| 16    | RMI_RTT_READ_ENTRY        | rmi::realm::test::rmi_rtt_create_positive        | PASS        |                                                |
| 17    | RMI_RTT_UNMAP_UNPROTECTED | rmi::rtt::test::rmi_rtt_map_unprotected_positive | PASS        |                                                |
| 18    | RMI_PSCI_COMPLETE         | rmi::rec::handlers::test::rmi_rec_enter_positive | PASS        |                                                |
| 19    | RMI_FEATURES              | rmi::features::test::rmi_features                | PASS        |                                                |
| 20    | RMI_RTT_FOLD              | rmi::rtt::test::rmi_rtt_fold_positive            | PASS        |                                                |
| 21    | RMI_REC_AUX_COUNT         | rmi::realm::test::rmi_rec_create_positive        | PASS        |                                                |
| 22    | RMI_RTT_INIT_RIPAS        | rmi::realm::test::rmi_rtt_init_positive          | PASS        |                                                |
| 23    | RMI_RTT_SET_RIPAS         | rmi::realm::test::rmi_rtt_set_positive           | PASS        | Bug Found: Integer Overflow                    |

*Related Issue: https://github.com/islet-project/islet/issues/361*