### PR TITLE
ci: scripts: Add code coverage measurement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,3 +256,28 @@ jobs:
         path: |
           unsafe-call-trace.log
           unsafe-items-list.log
+
+  code-coverage:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/cache@v3
+      with:
+        path: .git/modules/assets
+        key: ${{ runner.os }}-assets-${{ hashFiles('.gitmodules', 'assets') }}
+
+    - name: Install dependencies
+      run: |
+        ./scripts/deps/assets.sh
+        ./scripts/deps/rust.sh
+        ./scripts/deps/docker.sh
+        ./scripts/deps/cross.sh
+
+    - name: Measure code coverage
+      run: ./scripts/code-coverage.sh
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: code-coverage
+        path: code-coverage

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ third-party/*
 cli/islet
 sdk/sdk-example-c
 
+code-coverage/
 docs/
 
 rusty-tags.vi*

--- a/scripts/code-coverage.sh
+++ b/scripts/code-coverage.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+RMM=$ROOT/rmm
+OUT=$ROOT/out
+
+cd $RMM
+cross clean
+cargo clean
+RUSTFLAGS="-C instrument-coverage" cross test --target=aarch64-unknown-linux-gnu --lib
+
+rm -rf ../code-coverage
+grcov . -s . --binary-path $OUT/aarch64-unknown-linux-gnu/debug/ -t html --ignore tests/ -o ../code-coverage

--- a/scripts/deps/rust.sh
+++ b/scripts/deps/rust.sh
@@ -20,4 +20,8 @@ rustup component add clippy
 
 cargo install cargo-bloat cbindgen mdbook
 
+# code-coverage
+rustup component add llvm-tools-preview
+cargo install grcov
+
 rustc --version --verbose


### PR DESCRIPTION
This PR introduces the code coverage measurement .
Please refer the `code-coverage.sh` to run. Also you can check `code-coverage` files in the artifacts of [actions](https://github.com/islet-project/islet/actions).

## How to run
```sh
./scripts/code-coverage.sh
firefox ./code-coverage/index.thml
```