### PR TITLE
Move platform-dependent values from rmm/ to plat/

### DIFF
--- a/rmm/src/config.rs
+++ b/rmm/src/config.rs
@@ -15,3 +15,10 @@ pub const STACK_ALIGN: usize = 16;
 
 // TODO: Acquire this address properly.
 pub const RMM_SHARED_BUFFER_START: usize = 0xFFBFF000;
+
+pub struct PlatformMemoryLayout {
+    pub rmm_base: u64,
+    pub rw_start: u64,
+    pub rw_end: u64,
+    pub uart_phys: u64,
+}


### PR DESCRIPTION
This PR moves platform-dependent values to the platform-specific crate.
As a first step, it moves values that are defined by `the platform's linker script`.

Additionally, the constant `FVP_DRAM_REGION`, which defines the DRAM region for FVP, will also be moved in a next PR. 
(_Since this will requires more complex changes include `get_granule_if!`, I plan to address this in a separate PR._)