### PR TITLE
fix the hard-coded interface name

### DIFF
--- a/scripts/configure_tap.sh
+++ b/scripts/configure_tap.sh
@@ -29,6 +29,6 @@ sudo sysctl net.ipv6.conf.default.forwarding=1
 sudo sysctl net.ipv6.conf.all.forwarding=1
 
 # 3. set SNAT to allow FVP/Realm to connect internet through the host's network interface
-sudo iptables -A FORWARD -i enp3s0 -j ACCEPT
-sudo iptables -A FORWARD -o enp3s0 -j ACCEPT
+sudo iptables -A FORWARD -i ${ifname} -j ACCEPT
+sudo iptables -A FORWARD -o ${ifname} -j ACCEPT
 sudo iptables -t nat -A POSTROUTING -s ${host_tap_ip}/24 -o ${ifname} -j SNAT --to ${host_ip}


### PR DESCRIPTION
This PR fixes a simple mistake in configure_tap.sh. (i.e., using interface names given instead of the hard-coded one)
This issue caused the realm to not be able to connect to the host.