### PR TITLE
Add a reference count in array-based granule status table

### DIFF
--- a/rmm/src/rec.rs
+++ b/rmm/src/rec.rs
@@ -155,7 +155,13 @@ impl Rec<'_> {
     fn get_owner(&self) -> Result<&Rd, Error> {
         match self.owner.get() {
             Some(owner) => Ok(owner),
-            None => Err(Error::RmiErrorRec),
+            None => {
+                // XXX: the below is added not to be reached
+                //      note that it can be assured by Rec's invariants
+                #[cfg(kani)]
+                kani::assume(false);
+                Err(Error::RmiErrorRec)
+            }
         }
     }
 

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -119,7 +119,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     listen!(mainloop, rmi::REALM_DESTROY, |arg, _ret, rmm| {
         // get the lock for Rd
         let mut rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
-        #[cfg(feature = "gst_page_table")]
         if rd_granule.num_children() > 0 {
             return Err(Error::RmiErrorRealm(0));
         }

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -126,11 +126,6 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         let rd = rd_granule.content::<Rd>()?;
         let vmid = rd.id();
 
-        #[cfg(feature = "gst_page_table")]
-        if rd_granule.num_children() > 0 {
-            return Err(Error::RmiErrorRealm(0));
-        }
-
         let rtt_base = rd.rtt_base();
         for i in 0..rd.rtt_num_start() {
             let rtt = rtt_base + i * GRANULE_SIZE;

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -100,6 +100,9 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             set_granule(&mut rec_aux_granule, GranuleState::RecAux)?;
         }
 
+        #[cfg(not(feature = "gst_page_table"))]
+        rd_granule.inc_count();
+
         #[cfg(feature = "gst_page_table")]
         return set_granule_with_parent(rd_granule.clone(), &mut rec_granule, GranuleState::Rec);
         #[cfg(not(feature = "gst_page_table"))]
@@ -130,6 +133,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
             kani::assume(crate::granule::validate_addr(rec_aux));
             let mut rec_aux_granule = get_granule!(rec_aux)?;
             set_granule(&mut rec_aux_granule, GranuleState::Delegated)?;
+        }
+
+        #[cfg(not(feature = "gst_page_table"))]
+        {
+            let rd = rec.owner()?;
+            let mut rd_granule = get_granule_if!(rd, GranuleState::RD)?;
+            rd_granule.dec_count();
         }
 
         set_granule(&mut rec_granule, GranuleState::Delegated).map_err(|e| {

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -138,6 +138,13 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         #[cfg(not(feature = "gst_page_table"))]
         {
             let rd = rec.owner()?;
+            #[cfg(kani)]
+            {
+                // XXX: the below can be guaranteed by Rec's invariants instead
+                kani::assume(crate::granule::validate_addr(rd));
+                let rd_granule = get_granule!(rd)?;
+                kani::assume(rd_granule.state() == GranuleState::RD);
+            }
             let mut rd_granule = get_granule_if!(rd, GranuleState::RD)?;
             rd_granule.dec_count();
         }


### PR DESCRIPTION
This adds a reference count and `num_children` support in array-based granule status table missing of which was the main cause for the previous ACS failures when gst_page_table feature was not enabled. Most of ACS tests will be passed with this fix.

```
[before]
REGRESSION REPORT:
==================
   TOTAL TESTS     : 76
   TOTAL PASSED    : 24
   TOTAL FAILED    : 47
   TOTAL SKIPPED   : 3
   TOTAL SIM ERROR : 2
```

```
[after]
REGRESSION REPORT:
==================
   TOTAL TESTS     : 76
   TOTAL PASSED    : 71
   TOTAL FAILED    : 1
   TOTAL SKIPPED   : 3
   TOTAL SIM ERROR : 1
```