### PR TITLE
aarch64-cpu: Bump to upstream v10.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,9 @@ version = 3
 
 [[package]]
 name = "aarch64-cpu"
-version = "9.4.0"
-source = "git+https://github.com/islet-project/aarch64-cpu?branch=main#39369e6ed31e7fd8a03d1da37f6a1e14401bf647"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a21cd0131c25c438e19cd6a774adf7e3f64f7f4d723022882facc2dee0f8bc9"
 dependencies = [
  "tock-registers",
 ]

--- a/plat/fvp/Cargo.toml
+++ b/plat/fvp/Cargo.toml
@@ -19,7 +19,7 @@ stat = ["islet_rmm/stat"]
 gst_page_table = ["islet_rmm/gst_page_table"]
 
 [dependencies]
-aarch64-cpu = { git = "https://github.com/islet-project/aarch64-cpu", branch = "main" }
+aarch64-cpu = { version = "10.0.0" }
 bitflags = "1.3"
 islet_rmm = { path = "../../rmm" }
 linked_list_allocator = "0.10.4"

--- a/rmm/Cargo.toml
+++ b/rmm/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Islet Contributors"]
 edition = "2021"
 
 [dependencies]
-aarch64-cpu = { git = "https://github.com/islet-project/aarch64-cpu", branch = "main" }
+aarch64-cpu = { version = "10.0.0" }
 armv9a = { path = "../lib/armv9a" }
 ciborium = { version = "*", default-features = false, path = "../third-party/ciborium/ciborium" }
 coset = { version = "*", path = "../third-party/coset" }


### PR DESCRIPTION
The [PR](https://github.com/rust-embedded/aarch64-cpu/pull/27) merged and released at [v10.0.0](https://github.com/rust-embedded/aarch64-cpu/releases/tag/v10.0.0).

- The PR includes registers that we need
- I will remove the forked git, [islet-project/aarch64-cpu](https://github.com/islet-project/aarch64-cpu/), after this PR merged