### PR TITLE
spec: feedback: Remove a failure condition

### DIFF
--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -395,13 +395,6 @@ mod test {
             assert!(rd_obj.at_state(State::New));
         };
 
-        // This seems that it should be a failure condition
-        unsafe {
-            let rd_obj = &mut *(rd as *mut Rd);
-            rd_obj.set_state(State::SystemOff);
-            assert!(rd_obj.at_state(State::SystemOff));
-        };
-
         for (rtt, ipa, level) in &test_data {
             let ret = rmi::<RTT_CREATE>(&[rd, *rtt, *ipa, *level]);
             assert_eq!(ret[0], SUCCESS);


### PR DESCRIPTION
The below feedback would be accepted in 1.1-alp10.

## Feedback
8466a917 spec: feedback: Ensuring realm_state validation in B4.3.1

## Reply from Arm
The flow description has been amended, to remove the constraint on the Realm state. This change will be included in 1.1-alp10.

that is: ( the last line is removed)
    D1.2.2 Realm Translation Table creation flow
    Subsequent levels of RTT are added using the RMI_RTT_CREATE command.
(-) This can be performed when the state of the Realm is REALM_NEW or REALM_ACTIVE.