### PR TITLE
Refactor event handling logic & Handle the data abort case

### DIFF
--- a/rmm/src/event/mainloop.rs
+++ b/rmm/src/event/mainloop.rs
@@ -1,165 +1,27 @@
-extern crate alloc;
-
 use super::Context;
 use crate::asm::smc;
 use crate::rmi;
-use crate::rmi::error::Error;
-use crate::Monitor;
 
-use alloc::boxed::Box;
-use alloc::collections::btree_map::BTreeMap;
-use alloc::collections::vec_deque::VecDeque;
-use spin::mutex::Mutex;
-
-pub type Handler = Box<dyn Fn(&[usize], &mut [usize], &Monitor) -> Result<(), Error>>;
-
-pub struct Mainloop {
-    pub queue: Mutex<VecDeque<Context>>, // TODO: we need a more realistic queue considering multi-core environments if needed
-    pub on_event: BTreeMap<usize, Handler>,
-}
+pub struct Mainloop;
 
 impl Mainloop {
     pub fn new() -> Self {
-        Self {
-            queue: Mutex::new(VecDeque::new()),
-            on_event: BTreeMap::new(),
-        }
+        Self
     }
 
     #[cfg(not(kani))]
-    pub fn add_event_handlers(&mut self) {
-        rmi::features::set_event_handler(self);
-        rmi::gpt::set_event_handler(self);
-        rmi::realm::set_event_handler(self);
-        rmi::rec::set_event_handler(self);
-        rmi::rtt::set_event_handler(self);
-        rmi::version::set_event_handler(self);
-    }
-    #[cfg(kani)]
-    fn add_event_handlers(&mut self) {
-        #[cfg(feature = "mc_rmi_features")]
-        rmi::features::set_event_handler(self);
-        #[cfg(any(
-            feature = "mc_rmi_granule_delegate",
-            feature = "mc_rmi_granule_undelegate"
-        ))]
-        rmi::gpt::set_event_handler(self);
-        #[cfg(any(
-            feature = "mc_rmi_realm_activate",
-            feature = "mc_rmi_realm_destroy",
-            feature = "mc_rmi_rec_aux_count"
-        ))]
-        rmi::realm::set_event_handler(self);
-        #[cfg(feature = "mc_rmi_rec_destroy")]
-        rmi::rec::set_event_handler(self);
-        #[cfg(feature = "mc_rmi_version")]
-        rmi::version::set_event_handler(self);
-    }
-
-    #[cfg(not(kani))]
-    pub fn boot_complete(&mut self) {
-        let mut ctx = Context::new(rmi::BOOT_COMPLETE);
-        ctx.init_arg(&[rmi::BOOT_SUCCESS]);
-
-        self.add_event_handlers();
-        self.dispatch(ctx);
-    }
-    #[cfg(kani)]
-    // DIFF: `symbolic` parameter is added to pass symbolic input
-    pub fn boot_complete(&mut self, symbolic: [usize; 8]) {
-        let mut ctx = Context::new(rmi::BOOT_COMPLETE);
-        ctx.init_arg(&[rmi::BOOT_SUCCESS]);
-
-        self.add_event_handlers();
-        self.dispatch(ctx, symbolic);
-    }
-
-    #[cfg(not(kani))]
-    pub fn dispatch(&self, ctx: Context) {
+    pub fn dispatch(&self, ctx: Context) -> Context {
         let ret = smc(ctx.cmd(), ctx.arg_slice());
         let cmd = ret[0];
-
-        rmi::constraint::validate(
-            cmd,
-            |arg_num, ret_num| {
-                let mut ctx = Context::new(cmd);
-                ctx.init_arg(&ret[1..arg_num]);
-                ctx.resize_ret(ret_num);
-                self.queue.lock().push_back(ctx);
-            },
-            || {
-                let ctx = Context::new(rmi::NOT_SUPPORTED_YET);
-                self.queue.lock().push_back(ctx);
-            },
-        );
+        rmi::constraint::validate(cmd, &ret[1..])
     }
+
     #[cfg(kani)]
     // DIFF: `symbolic` parameter is added to pass symbolic input
-    pub fn dispatch(&self, ctx: Context, symbolic: [usize; 8]) {
+    pub fn dispatch(&self, ctx: Context, symbolic: [usize; 8]) -> Context {
         let _ret = smc(ctx.cmd(), ctx.arg_slice());
         let ret = symbolic;
         let cmd = ret[0];
-
-        rmi::constraint::validate(
-            cmd,
-            |arg_num, ret_num| {
-                let mut ctx = Context::new(cmd);
-                ctx.init_arg(&ret[1..arg_num]);
-                ctx.resize_ret(ret_num);
-                self.queue.lock().push_back(ctx);
-            },
-            || {
-                let ctx = Context::new(rmi::NOT_SUPPORTED_YET);
-                self.queue.lock().push_back(ctx);
-            },
-        );
-    }
-
-    #[cfg(not(kani))]
-    pub fn run(&self, monitor: &Monitor) {
-        loop {
-            let mut ctx = self.queue.lock().pop_front().unwrap(); // TODO: remove unwrap here, by introducing a more realistic queue
-            if self.on_event.is_empty() {
-                panic!("There is no registered event handler.");
-            }
-
-            match self.on_event.get(&ctx.cmd) {
-                Some(handler) => {
-                    ctx.do_rmi(|arg, ret| handler(arg, ret, monitor));
-                }
-                None => {
-                    error!("Not registered event: {:X}", ctx.cmd);
-                    ctx.init_arg(&[rmi::RET_FAIL]);
-                }
-            };
-
-            ctx.cmd = rmi::REQ_COMPLETE;
-            self.dispatch(ctx);
-        }
-    }
-    #[cfg(kani)]
-    // DIFF: infinite loop is removed
-    //       return value is added to track output
-    pub fn run(&self, monitor: &Monitor) -> [usize; 5] {
-        let mut ctx = self.queue.lock().pop_front().unwrap();
-
-        if self.on_event.is_empty() {
-            panic!("There is no registered event handler.");
-        }
-
-        match self.on_event.get(&ctx.cmd()) {
-            Some(handler) => ctx.do_rmi(|arg, ret| handler(arg, ret, monitor)),
-            None => {
-                assert!(false);
-                error!("Not registered event: {:X}", ctx.cmd());
-                ctx.init_arg(&[rmi::RET_FAIL]);
-
-                return [0; 5]; // this is a bogus statement to meet the return type
-            }
-        }
-    }
-
-    pub fn add_event_handler(&mut self, code: usize, handler: Handler) {
-        self.on_event.insert(code, handler);
+        rmi::constraint::validate(cmd, &ret[1..])
     }
 }

--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -1,10 +1,12 @@
 pub mod mainloop;
 pub mod realmexit;
+pub mod rmihandle;
 pub mod rsihandle;
 
 pub use crate::rmi::error::Error;
 pub use crate::{rmi, rsi};
 pub use mainloop::Mainloop;
+pub use rmihandle::RmiHandle;
 pub use rsihandle::RsiHandle;
 
 extern crate alloc;

--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -4,7 +4,7 @@ pub mod rmihandle;
 pub mod rsihandle;
 
 pub use crate::rmi::error::Error;
-pub use crate::{rmi, rsi};
+pub use crate::rsi;
 pub use mainloop::Mainloop;
 pub use rmihandle::RmiHandle;
 pub use rsihandle::RsiHandle;
@@ -62,64 +62,6 @@ impl Context {
 
     pub fn cmd(&self) -> Command {
         self.cmd
-    }
-
-    pub fn do_rmi<F>(&mut self, handler: F) -> [usize; 5]
-    where
-        F: Fn(&[usize], &mut [usize]) -> Result<(), Error>,
-    {
-        let mut result = [0; 5];
-        self.ret[0] = rmi::SUCCESS;
-
-        #[cfg(feature = "stat")]
-        {
-            if self.cmd != rmi::REC_ENTER {
-                trace!("let's get STATS.lock() with cmd {}", rmi::to_str(self.cmd));
-                crate::stat::STATS.lock().measure(self.cmd, || {
-                    if let Err(code) = handler(&self.arg[..], &mut self.ret[..]) {
-                        self.ret[0] = code.into();
-                    }
-                });
-            } else if let Err(code) = handler(&self.arg[..], &mut self.ret[..]) {
-                self.ret[0] = code.into();
-            }
-        }
-        #[cfg(not(feature = "stat"))]
-        {
-            if let Err(code) = handler(&self.arg[..], &mut self.ret[..]) {
-                self.ret[0] = code.into();
-            }
-        }
-
-        trace!(
-            "RMI: {0: <20} {1:X?} > {2:X?}",
-            rmi::to_str(self.cmd),
-            &self.arg,
-            &self.ret
-        );
-
-        self.arg.clear();
-        self.arg.extend_from_slice(&self.ret[..]);
-
-        let ret_len = self.ret.len();
-        #[cfg(kani)]
-        // the below is a proof helper
-        {
-            #[cfg(any(
-                feature = "mc_rmi_granule_delegate",
-                feature = "mc_rmi_granule_undelegate",
-                feature = "mc_rmi_realm_activate",
-                feature = "mc_rmi_realm_destroy",
-                feature = "mc_rmi_rec_destroy"
-            ))]
-            assert!(ret_len == 1);
-            #[cfg(any(feature = "mc_rmi_rec_aux_count", feature = "mc_rmi_features"))]
-            assert!(ret_len == 2);
-            #[cfg(feature = "mc_rmi_version")]
-            assert!(ret_len == 3);
-        }
-        result[..ret_len].copy_from_slice(&self.ret[..]);
-        result
     }
 
     pub fn do_rsi<F>(&mut self, mut handler: F)

--- a/rmm/src/event/rmihandle.rs
+++ b/rmm/src/event/rmihandle.rs
@@ -1,0 +1,59 @@
+extern crate alloc;
+
+use crate::rmi;
+use crate::rmi::error::Error;
+use crate::Monitor;
+
+use alloc::boxed::Box;
+use alloc::collections::btree_map::BTreeMap;
+
+pub type Handler = Box<dyn Fn(&[usize], &mut [usize], &Monitor) -> Result<(), Error>>;
+
+pub struct RmiHandle {
+    pub on_event: BTreeMap<usize, Handler>,
+}
+
+impl RmiHandle {
+    pub fn new() -> Self {
+        let mut rmi = Self {
+            on_event: BTreeMap::new(),
+        };
+        rmi.add_event_handlers();
+        rmi
+    }
+
+    #[cfg(not(kani))]
+    pub fn add_event_handlers(&mut self) {
+        rmi::features::set_event_handler(self);
+        rmi::gpt::set_event_handler(self);
+        rmi::realm::set_event_handler(self);
+        rmi::rec::set_event_handler(self);
+        rmi::rtt::set_event_handler(self);
+        rmi::version::set_event_handler(self);
+    }
+
+    #[cfg(kani)]
+    fn add_event_handlers(&mut self) {
+        #[cfg(feature = "mc_rmi_features")]
+        rmi::features::set_event_handler(self);
+        #[cfg(any(
+            feature = "mc_rmi_granule_delegate",
+            feature = "mc_rmi_granule_undelegate"
+        ))]
+        rmi::gpt::set_event_handler(self);
+        #[cfg(any(
+            feature = "mc_rmi_realm_activate",
+            feature = "mc_rmi_realm_destroy",
+            feature = "mc_rmi_rec_aux_count"
+        ))]
+        rmi::realm::set_event_handler(self);
+        #[cfg(feature = "mc_rmi_rec_destroy")]
+        rmi::rec::set_event_handler(self);
+        #[cfg(feature = "mc_rmi_version")]
+        rmi::version::set_event_handler(self);
+    }
+
+    pub fn add_event_handler(&mut self, code: usize, handler: Handler) {
+        self.on_event.insert(code, handler);
+    }
+}

--- a/rmm/src/event/rsihandle.rs
+++ b/rmm/src/event/rsihandle.rs
@@ -1,14 +1,11 @@
 extern crate alloc;
 
-use super::Context;
-
 use crate::rec::Rec;
 use crate::rmi::rec::run::Run;
 use crate::rsi;
 use crate::rsi::psci;
 use crate::Monitor;
 // TODO: Change this into rsi::error::Error
-use crate::realm::context::set_reg;
 use crate::rmi::error::Error;
 
 use alloc::boxed::Box;
@@ -32,33 +29,6 @@ impl RsiHandle {
         };
         rsi.set_event_handlers();
         rsi
-    }
-
-    pub fn dispatch(
-        &self,
-        ctx: &mut Context,
-        monitor: &Monitor,
-        rec: &mut Rec<'_>,
-        run: &mut Run,
-    ) -> usize {
-        match self.on_event.get(&ctx.cmd) {
-            Some(handler) => {
-                ctx.do_rsi(|arg, ret| handler(arg, ret, monitor, rec, run));
-            }
-            None => {
-                ctx.init_ret(&[RsiHandle::NOT_SUPPORTED]);
-                error!(
-                    "Not registered event: {:X} returning {:X}",
-                    ctx.cmd,
-                    RsiHandle::NOT_SUPPORTED
-                );
-                // TODO: handle the error properly
-                let _ = set_reg(rec, 0, RsiHandle::NOT_SUPPORTED);
-
-                return RsiHandle::RET_FAIL;
-            }
-        }
-        RsiHandle::RET_SUCCESS
     }
 
     fn set_event_handlers(&mut self) {

--- a/rmm/src/exception/trap.rs
+++ b/rmm/src/exception/trap.rs
@@ -7,7 +7,6 @@ use self::syndrome::Syndrome;
 use super::lower::synchronous;
 use crate::cpu;
 use crate::event::realmexit::{ExitSyncType, RecExitReason};
-use crate::mm::translation::PageTable;
 use crate::rec::Rec;
 
 use aarch64_cpu::registers::*;
@@ -65,7 +64,6 @@ pub extern "C" fn handle_exception(info: Info, esr: u32, tf: &mut TrapFrame) {
                     }
                     Fault::Translation { level } => {
                         debug!("translation, level:{}, esr:{:X}", level, esr);
-                        PageTable::get_ref().map(far as usize, true);
                     }
                     Fault::AccessFlag { level } => {
                         debug!("access flag, level:{}", level);

--- a/rmm/src/host.rs
+++ b/rmm/src/host.rs
@@ -3,7 +3,6 @@ use crate::granule::validate_addr;
 use crate::granule::{is_not_in_realm, GRANULE_SIZE};
 #[cfg(not(feature = "gst_page_table"))]
 use crate::granule::{GranuleState, GRANULE_SIZE};
-use crate::mm::translation::PageTable;
 #[cfg(not(feature = "gst_page_table"))]
 use crate::{get_granule, get_granule_if};
 
@@ -20,10 +19,7 @@ pub fn copy_from<T: SafetyChecked + SafetyAssured + Copy>(addr: usize) -> Option
         return None;
     }
 
-    PageTable::get_ref().map(addr, false);
     let ret = assume_safe::<T>(addr).map(|safety_assumed| *safety_assumed);
-    PageTable::get_ref().unmap(addr);
-
     match ret {
         Ok(obj) => Some(obj),
         Err(err) => {
@@ -43,10 +39,7 @@ pub fn copy_to_obj<T: SafetyChecked + SafetyAssured + Copy>(src: usize, dst: &mu
         return None;
     }
 
-    PageTable::get_ref().map(src, false);
     let ret = assume_safe::<T>(src).map(|safety_assumed| *dst = *safety_assumed);
-    PageTable::get_ref().unmap(src);
-
     match ret {
         Ok(_) => Some(()),
         Err(err) => {
@@ -66,10 +59,7 @@ pub fn copy_to_ptr<T: SafetyChecked + SafetyAssured + Copy>(src: &T, dst: usize)
         return None;
     }
 
-    PageTable::get_ref().map(dst, false);
     let ret = assume_safe::<T>(dst).map(|mut safety_assumed| *safety_assumed = *src);
-    PageTable::get_ref().unmap(dst);
-
     match ret {
         Ok(_) => Some(()),
         Err(err) => {

--- a/rmm/src/monitor.rs
+++ b/rmm/src/monitor.rs
@@ -16,7 +16,10 @@ pub struct Monitor {
 #[cfg(kani)]
 // `rsi` and `page_table` are removed in model checking harnesses
 // to reduce overall state space
-pub struct Monitor {}
+pub struct Monitor {
+    pub rmi: RmiHandle,
+    mainloop: Mainloop,
+}
 
 impl Monitor {
     #[cfg(not(kani))]
@@ -31,7 +34,10 @@ impl Monitor {
 
     #[cfg(kani)]
     pub fn new() -> Self {
-        Self {}
+        Self {
+            rmi: RmiHandle::new(),
+            mainloop: Mainloop::new(),
+        }
     }
 
     #[cfg(not(kani))]
@@ -132,6 +138,7 @@ impl Monitor {
     }
 
     pub fn handle_rsi(&self, ctx: &mut Context, rec: &mut Rec<'_>, run: &mut Run) -> usize {
+        #[cfg(not(kani))]
         match self.rsi.on_event.get(&ctx.cmd) {
             Some(handler) => {
                 ctx.do_rsi(|arg, ret| handler(arg, ret, self, rec, run));

--- a/rmm/src/monitor.rs
+++ b/rmm/src/monitor.rs
@@ -1,7 +1,9 @@
 use crate::event::{Context, Mainloop, RmiHandle, RsiHandle};
 use crate::mm::translation::PageTable;
-
+use crate::realm::context::set_reg;
+use crate::rec::Rec;
 use crate::rmi;
+use crate::rmi::rec::run::Run;
 
 #[cfg(not(kani))]
 pub struct Monitor {
@@ -52,17 +54,7 @@ impl Monitor {
         let mut ctx = self.boot_complete();
 
         loop {
-            match self.rmi.on_event.get(&ctx.cmd) {
-                Some(handler) => {
-                    ctx.do_rmi(|arg, ret| handler(arg, ret, self));
-                }
-                None => {
-                    error!("Not registered event: {:X}", ctx.cmd);
-                    ctx.init_arg(&[rmi::RET_FAIL]);
-                }
-            };
-
-            ctx.cmd = rmi::REQ_COMPLETE;
+            self.handle_rmi(&mut ctx);
             ctx = self.mainloop.dispatch(ctx);
         }
     }
@@ -70,21 +62,93 @@ impl Monitor {
     #[cfg(kani)]
     // DIFF: `symbolic` parameter is added to pass symbolic input
     //       return value is added to track output
-    pub fn run(&self, symbolic: [usize; 8]) -> [usize; 5] {
+    //       infinite loop is removed
+    pub fn run(&mut self, symbolic: [usize; 8]) -> [usize; 5] {
         let mut ctx = self.boot_complete(symbolic);
+        let mut result = [0; 5];
 
-        match self.rmi.on_event.get(&ctx.cmd) {
-            Some(handler) => ctx.do_rmi(|arg, ret| handler(arg, ret, self)),
-            None => {
-                assert!(false);
-                error!("Not registered event: {:X}", ctx.cmd);
-                ctx.init_arg(&[rmi::RET_FAIL]);
+        self.handle_rmi(&mut ctx);
+        ctx = self.mainloop.dispatch(ctx, symbolic);
+        let ret_len = ctx.ret.len();
+        result[..ret_len].copy_from_slice(&ctx.ret[..]);
+        result
+    }
 
-                return [0; 5]; // this is a bogus statement to meet the return type
+    pub fn handle_rmi(&mut self, ctx: &mut Context) {
+        if let Some(handler) = self.rmi.on_event.get(&ctx.cmd) {
+            #[cfg(feature = "stat")]
+            {
+                if ctx.cmd != rmi::REC_ENTER {
+                    trace!("let's get STATS.lock() with cmd {}", rmi::to_str(ctx.cmd));
+                    crate::stat::STATS.lock().measure(ctx.cmd, || {
+                        if let Err(code) = handler(&ctx.arg[..], &mut ctx.ret[..], self) {
+                            self.ret[0] = code.into();
+                        }
+                    });
+                } else if let Err(code) = handler(&ctx.arg[..], &mut ctx.ret[..], self) {
+                    ctx.ret[0] = code.into();
+                }
             }
-        };
+            #[cfg(not(feature = "stat"))]
+            {
+                if let Err(code) = handler(&ctx.arg[..], &mut ctx.ret[..], self) {
+                    ctx.ret[0] = code.into();
+                }
+            }
+
+            trace!(
+                "RMI: {0: <20} {1:X?} > {2:X?}",
+                rmi::to_str(ctx.cmd),
+                &ctx.arg,
+                &ctx.ret
+            );
+
+            ctx.arg.clear();
+            ctx.arg.extend_from_slice(&ctx.ret[..]);
+
+            #[cfg(kani)]
+            // the below is a proof helper
+            {
+                let ret_len = ctx.ret.len();
+                #[cfg(any(
+                    feature = "mc_rmi_granule_delegate",
+                    feature = "mc_rmi_granule_undelegate",
+                    feature = "mc_rmi_realm_activate",
+                    feature = "mc_rmi_realm_destroy",
+                    feature = "mc_rmi_rec_destroy"
+                ))]
+                assert!(ret_len == 1);
+                #[cfg(any(feature = "mc_rmi_rec_aux_count", feature = "mc_rmi_features"))]
+                assert!(ret_len == 2);
+                #[cfg(feature = "mc_rmi_version")]
+                assert!(ret_len == 3);
+            }
+        } else {
+            error!("Not registered event: {:X}", ctx.cmd);
+            ctx.init_arg(&[rmi::RET_FAIL]);
+        }
 
         ctx.cmd = rmi::REQ_COMPLETE;
-        ctx = self.mainloop.dispatch(ctx, symbolic);
+    }
+
+    pub fn handle_rsi(&self, ctx: &mut Context, rec: &mut Rec<'_>, run: &mut Run) -> usize {
+        match self.rsi.on_event.get(&ctx.cmd) {
+            Some(handler) => {
+                ctx.do_rsi(|arg, ret| handler(arg, ret, self, rec, run));
+            }
+            None => {
+                ctx.init_ret(&[RsiHandle::NOT_SUPPORTED]);
+                error!(
+                    "Not registered event: {:X} returning {:X}",
+                    ctx.cmd,
+                    RsiHandle::NOT_SUPPORTED
+                );
+                // TODO: handle the error properly
+                let _ = set_reg(rec, 0, RsiHandle::NOT_SUPPORTED);
+
+                return RsiHandle::RET_FAIL;
+            }
+        }
+        RsiHandle::RET_SUCCESS
     }
 }

--- a/rmm/src/monitor.rs
+++ b/rmm/src/monitor.rs
@@ -1,10 +1,14 @@
-use crate::event::{Mainloop, RsiHandle};
+use crate::event::{Context, Mainloop, RmiHandle, RsiHandle};
 use crate::mm::translation::PageTable;
+
+use crate::rmi;
 
 #[cfg(not(kani))]
 pub struct Monitor {
     pub rsi: RsiHandle,
+    pub rmi: RmiHandle,
     pub page_table: PageTable,
+    mainloop: Mainloop,
 }
 
 #[cfg(kani)]
@@ -17,26 +21,70 @@ impl Monitor {
     pub fn new() -> Self {
         Self {
             rsi: RsiHandle::new(),
+            rmi: RmiHandle::new(),
             page_table: PageTable::get_ref(),
+            mainloop: Mainloop::new(),
         }
     }
+
     #[cfg(kani)]
     pub fn new() -> Self {
         Self {}
     }
 
     #[cfg(not(kani))]
-    pub fn run(&self) {
-        let mut mainloop = Mainloop::new();
-        mainloop.boot_complete();
-        mainloop.run(self)
+    fn boot_complete(&self) -> Context {
+        let mut ctx = Context::new(rmi::BOOT_COMPLETE);
+        ctx.init_arg(&[rmi::BOOT_SUCCESS]);
+        self.mainloop.dispatch(ctx)
     }
+
+    #[cfg(kani)]
+    // DIFF: `symbolic` parameter is added to pass symbolic input
+    pub fn boot_complete(&mut self, symbolic: [usize; 8]) -> Context {
+        let mut ctx = Context::new(rmi::BOOT_COMPLETE);
+        ctx.init_arg(&[rmi::BOOT_SUCCESS]);
+        self.mainloop.dispatch(ctx, symbolic)
+    }
+
+    #[cfg(not(kani))]
+    pub fn run(&mut self) {
+        let mut ctx = self.boot_complete();
+
+        loop {
+            match self.rmi.on_event.get(&ctx.cmd) {
+                Some(handler) => {
+                    ctx.do_rmi(|arg, ret| handler(arg, ret, self));
+                }
+                None => {
+                    error!("Not registered event: {:X}", ctx.cmd);
+                    ctx.init_arg(&[rmi::RET_FAIL]);
+                }
+            };
+
+            ctx.cmd = rmi::REQ_COMPLETE;
+            ctx = self.mainloop.dispatch(ctx);
+        }
+    }
+
     #[cfg(kani)]
     // DIFF: `symbolic` parameter is added to pass symbolic input
     //       return value is added to track output
     pub fn run(&self, symbolic: [usize; 8]) -> [usize; 5] {
-        let mut mainloop = Mainloop::new();
-        mainloop.boot_complete(symbolic);
-        mainloop.run(self)
+        let mut ctx = self.boot_complete(symbolic);
+
+        match self.rmi.on_event.get(&ctx.cmd) {
+            Some(handler) => ctx.do_rmi(|arg, ret| handler(arg, ret, self)),
+            None => {
+                assert!(false);
+                error!("Not registered event: {:X}", ctx.cmd);
+                ctx.init_arg(&[rmi::RET_FAIL]);
+
+                return [0; 5]; // this is a bogus statement to meet the return type
+            }
+        };
+
+        ctx.cmd = rmi::REQ_COMPLETE;
+        ctx = self.mainloop.dispatch(ctx, symbolic);
     }
 }

--- a/rmm/src/realm/mm/rtt.rs
+++ b/rmm/src/realm/mm/rtt.rs
@@ -1,7 +1,6 @@
 use crate::granule::GRANULE_SHIFT;
 use crate::granule::{set_granule, GranuleState};
 use crate::measurement::HashContext;
-use crate::mm::translation::PageTable as mmPageTable;
 use crate::realm::mm::address::GuestPhysAddr;
 use crate::realm::mm::attribute::{desc_type, memattr, permission, shareable};
 use crate::realm::mm::entry;
@@ -66,9 +65,6 @@ pub fn create(rd: &Rd, rtt_addr: usize, ipa: usize, level: usize) -> Result<(), 
 
     let map_size = mapping_size(level);
 
-    // The below is added to avoid a fault regarding the RTT entry
-    // during the below `create_pgtbl_at()`
-    mmPageTable::get_ref().map(rtt_addr, true);
     if parent_s2tte.is_unassigned() {
         if parent_s2tte.is_invalid_ripas() {
             panic!("invalid ripas");

--- a/rmm/src/rmi/constraint.rs
+++ b/rmm/src/rmi/constraint.rs
@@ -1,4 +1,4 @@
-use crate::event::Command;
+use crate::event::{Command, Context};
 use crate::rmi;
 
 #[allow(dead_code)]
@@ -56,15 +56,13 @@ fn pick(cmd: Command) -> Option<Constraint> {
     Some(constraint)
 }
 
-pub fn validate<T, G>(cmd: Command, ok_func: T, else_func: G)
-where
-    T: Fn(usize, usize),
-    G: FnOnce(), // TODO: error command?
-{
+pub fn validate(cmd: Command, arg: &[usize]) -> Context {
     if let Some(c) = pick(cmd) {
-        // TODO: command-specific validation routine if needed
-        ok_func(c.arg_num, c.ret_num);
+        let mut ctx = Context::new(cmd);
+        ctx.init_arg(&arg[..c.arg_num]);
+        ctx.resize_ret(c.ret_num);
+        ctx
     } else {
-        else_func();
+        Context::new(rmi::NOT_SUPPORTED_YET)
     }
 }

--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -1,4 +1,4 @@
-use crate::event::Mainloop;
+use crate::event::RmiHandle;
 use crate::listen;
 use crate::rmi;
 
@@ -41,8 +41,8 @@ fn mask(shift: usize, width: usize) -> usize {
     (!0usize >> (64usize - width)) << shift
 }
 
-pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::FEATURES, |arg, ret, _| {
+pub fn set_event_handler(rmi: &mut RmiHandle) {
+    listen!(rmi, rmi::FEATURES, |arg, ret, _| {
         if arg[0] != FEATURE_REGISTER_0_INDEX {
             ret[1] = 0;
             return Ok(());

--- a/rmm/src/rmi/gpt.rs
+++ b/rmm/src/rmi/gpt.rs
@@ -1,5 +1,5 @@
 use crate::asm::{smc, SMC_SUCCESS};
-use crate::event::Mainloop;
+use crate::event::RmiHandle;
 use crate::granule::{set_granule, GranuleState};
 use crate::listen;
 use crate::rmi;
@@ -18,9 +18,9 @@ extern crate alloc;
 pub const MARK_REALM: usize = 0xc400_01b0;
 pub const MARK_NONSECURE: usize = 0xc400_01b1;
 
-pub fn set_event_handler(mainloop: &mut Mainloop) {
+pub fn set_event_handler(rmi: &mut RmiHandle) {
     #[cfg(any(not(kani), feature = "mc_rmi_granule_delegate"))]
-    listen!(mainloop, rmi::GRANULE_DELEGATE, |arg, _, rmm| {
+    listen!(rmi, rmi::GRANULE_DELEGATE, |arg, _, rmm| {
         let addr = arg[0];
 
         #[cfg(feature = "gst_page_table")]
@@ -58,7 +58,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     });
 
     #[cfg(any(not(kani), feature = "mc_rmi_granule_undelegate"))]
-    listen!(mainloop, rmi::GRANULE_UNDELEGATE, |arg, _, rmm| {
+    listen!(rmi, rmi::GRANULE_UNDELEGATE, |arg, _, rmm| {
         let addr = arg[0];
         let mut granule = get_granule_if!(addr, GranuleState::Delegated)?;
 

--- a/rmm/src/rmi/rec/handlers.rs
+++ b/rmm/src/rmi/rec/handlers.rs
@@ -96,6 +96,7 @@ pub fn set_event_handler(rmi: &mut RmiHandle) {
 
         for i in 0..rmi::MAX_REC_AUX_GRANULES {
             let rec_aux = rec.aux(i) as usize;
+            rmm.page_table.map(rec_aux, true);
             let mut rec_aux_granule = get_granule_if!(rec_aux, GranuleState::Delegated)?;
             set_granule(&mut rec_aux_granule, GranuleState::RecAux)?;
         }
@@ -123,6 +124,7 @@ pub fn set_event_handler(rmi: &mut RmiHandle) {
             let rec_aux = rec.aux(i) as usize;
             let mut rec_aux_granule = get_granule_if!(rec_aux, GranuleState::RecAux)?;
             set_granule(&mut rec_aux_granule, GranuleState::Delegated)?;
+            rmm.page_table.unmap(rec_aux);
         }
         #[cfg(kani)]
         {

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -56,6 +56,7 @@ pub fn set_event_handler(rmi: &mut RmiHandle) {
 
         // The below is added to avoid a fault regarding the RTT entry
         // during the `create_pgtbl_at()` in `rtt::create()`.
+        #[cfg(not(kani))]
         rmm.page_table.map(rtt_addr, true);
         rtt::create(&rd, rtt_addr, ipa, level)?;
         set_granule(&mut rtt_granule, GranuleState::RTT)?;
@@ -197,8 +198,10 @@ pub fn set_event_handler(rmi: &mut RmiHandle) {
         rmm.page_table.map(target_pa, true);
 
         // copy src to target
+        #[cfg(not(kani))]
         rmm.page_table.map(src_pa, false);
         host::copy_to_obj::<DataPage>(src_pa, &mut target_page).ok_or(Error::RmiErrorInput)?;
+        #[cfg(not(kani))]
         rmm.page_table.unmap(src_pa);
 
         // map ipa to taget_pa in S2 table

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use crate::event::Mainloop;
+use crate::event::RmiHandle;
 use crate::granule::{
     is_granule_aligned, is_not_in_realm, set_granule, GranuleState, GRANULE_SIZE,
 };
@@ -35,8 +35,8 @@ fn is_valid_rtt_cmd(rd: &Rd, ipa: usize, level: usize) -> bool {
     true
 }
 
-pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::RTT_CREATE, |arg, _ret, _rmm| {
+pub fn set_event_handler(rmi: &mut RmiHandle) {
+    listen!(rmi, rmi::RTT_CREATE, |arg, _ret, _rmm| {
         let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rtt_addr = arg[1];
         let rd = rd_granule.content::<Rd>()?;
@@ -58,7 +58,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::RTT_DESTROY, |arg, ret, _rmm| {
+    listen!(rmi, rmi::RTT_DESTROY, |arg, ret, _rmm| {
         let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>()?;
         let ipa = arg[1];
@@ -78,7 +78,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::RTT_INIT_RIPAS, |arg, ret, _rmm| {
+    listen!(rmi, rmi::RTT_INIT_RIPAS, |arg, ret, _rmm| {
         let mut rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let mut rd = rd_granule.content_mut::<Rd>()?;
         let base = arg[1];
@@ -106,7 +106,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::RTT_SET_RIPAS, |arg, ret, _rmm| {
+    listen!(rmi, rmi::RTT_SET_RIPAS, |arg, ret, _rmm| {
         let base = arg[2];
         let top = arg[3];
 
@@ -142,7 +142,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::RTT_READ_ENTRY, |arg, ret, _rmm| {
+    listen!(rmi, rmi::RTT_READ_ENTRY, |arg, ret, _rmm| {
         let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>()?;
         let ipa = arg[1];
@@ -157,7 +157,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::DATA_CREATE, |arg, _ret, rmm| {
+    listen!(rmi, rmi::DATA_CREATE, |arg, _ret, rmm| {
         // target_pa: location where realm data is created.
         let rd = arg[0];
         let target_pa = arg[1];
@@ -206,7 +206,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::DATA_CREATE_UNKNOWN, |arg, _ret, rmm| {
+    listen!(rmi, rmi::DATA_CREATE_UNKNOWN, |arg, _ret, rmm| {
         // rd granule lock
         let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>()?;
@@ -236,7 +236,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
         Ok(())
     });
 
-    listen!(mainloop, rmi::DATA_DESTROY, |arg, ret, _rmm| {
+    listen!(rmi, rmi::DATA_DESTROY, |arg, ret, _rmm| {
         // rd granule lock
         let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>()?;
@@ -266,7 +266,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     });
 
     // Map an unprotected IPA to a non-secure PA.
-    listen!(mainloop, rmi::RTT_MAP_UNPROTECTED, |arg, _ret, _rmm| {
+    listen!(rmi, rmi::RTT_MAP_UNPROTECTED, |arg, _ret, _rmm| {
         let ipa = arg[1];
         let level = arg[2];
         let host_s2tte = arg[3];
@@ -287,7 +287,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     });
 
     // Unmap a non-secure PA at an unprotected IPA
-    listen!(mainloop, rmi::RTT_UNMAP_UNPROTECTED, |arg, ret, _rmm| {
+    listen!(rmi, rmi::RTT_UNMAP_UNPROTECTED, |arg, ret, _rmm| {
         let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>()?;
 
@@ -310,7 +310,7 @@ pub fn set_event_handler(mainloop: &mut Mainloop) {
     });
 
     // Destroy a homogeneous RTT and map as a bigger block at its parent RTT
-    listen!(mainloop, rmi::RTT_FOLD, |arg, ret, _rmm| {
+    listen!(rmi, rmi::RTT_FOLD, |arg, ret, _rmm| {
         let rd_granule = get_granule_if!(arg[0], GranuleState::RD)?;
         let rd = rd_granule.content::<Rd>()?;
         let ipa = arg[1];

--- a/rmm/src/rmi/version.rs
+++ b/rmm/src/rmi/version.rs
@@ -1,4 +1,4 @@
-use crate::event::Mainloop;
+use crate::event::RmiHandle;
 use crate::listen;
 use crate::rmi::{self, error::Error};
 
@@ -15,8 +15,8 @@ fn encode_version() -> usize {
     (rmi::ABI_MAJOR_VERSION << 16) | rmi::ABI_MINOR_VERSION
 }
 
-pub fn set_event_handler(mainloop: &mut Mainloop) {
-    listen!(mainloop, rmi::VERSION, |arg, ret, _| {
+pub fn set_event_handler(rmi: &mut RmiHandle) {
+    listen!(rmi, rmi::VERSION, |arg, ret, _| {
         let req = arg[0];
 
         let lower = encode_version();

--- a/rmm/src/rsi/constraint.rs
+++ b/rmm/src/rsi/constraint.rs
@@ -1,4 +1,4 @@
-use crate::event::Command;
+use crate::event::{Command, Context};
 use crate::rmi::constraint::Constraint; // TODO: we might need rsi's own constraint struct in the future
 use crate::rsi;
 
@@ -24,15 +24,14 @@ fn pick(cmd: Command) -> Option<Constraint> {
     Some(constraint)
 }
 
-pub fn validate<T>(cmd: Command, mut ok_func: T)
-where
-    T: FnMut(usize, usize),
-{
+pub fn validate(cmd: Command) -> Context {
+    let mut ctx = Context::new(cmd);
     if let Some(c) = pick(cmd) {
-        ok_func(c.arg_num, c.ret_num);
+        ctx.resize_ret(c.ret_num);
     } else {
-        // rsi.dispatch takes care of unregistered command.
+        // rmm.handle_rsi takes care of unregistered command.
         // Just limit the array size here.
-        ok_func(2, 1);
+        ctx.resize_ret(1);
     }
+    ctx
 }

--- a/rmm/src/test_utils.rs
+++ b/rmm/src/test_utils.rs
@@ -11,15 +11,13 @@ pub use mock::host::{alloc_granule, granule_addr};
 use alloc::vec::Vec;
 
 pub fn rmi<const COMMAND: usize>(arg: &[usize]) -> Vec<usize> {
-    let mut mainloop = Mainloop::new();
     let monitor = Monitor::new();
-    (&mut mainloop).add_event_handlers();
 
     let mut ctx = Context::new(COMMAND);
     ctx.init_arg(&arg);
     ctx.init_ret(&[0; 8]);
 
-    let handler = mainloop.on_event.get(&COMMAND).unwrap();
+    let handler = monitor.rmi.on_event.get(&COMMAND).unwrap();
     if let Err(code) = handler(&ctx.arg, &mut ctx.ret, &monitor) {
         ctx.ret[0] = code.into();
     }


### PR DESCRIPTION
This PR
 - refactors event handling logic
 - removes temporary mapping for handling data abort (https://github.com/islet-project/islet/pull/394/commits/011e2fae1f740601579eb8c40d40d1a53bd2821d)

_NOTE: I will submit the PR for managing the Page Table as a pinned object separately, as it is experimental._

# Refactor event handling logic

## Problem
- RMM handles two types of events: RSI and RMI,
  but RMI handler was located in the mainloop while RSI handler was part of RMM.
- The mainloop, created and managed by RMM, had a cyclic dependency
  as the RMI handler in the mainloop referenced the monitor.
- Handling RMI in the mainloop also required locking the event queue,
  leading to performance issues.

## Patch
- Centralized both RMI and RSI event handlers within RMM for consistent event management.
- Refactored mainloop to only poll for RMI events, following SRP principle.
- Removed mutual references between mainloop and monitor, breaking the cyclic dependency.
- Eliminated the need for queue locking by shifting event handling to RMM, improving performance.