### PR TITLE
clippy: Enable the missing_safety_doc rule

### DIFF
--- a/lib/vmsa/src/page_table.rs
+++ b/lib/vmsa/src/page_table.rs
@@ -57,12 +57,25 @@ pub trait Entry {
     fn points_to_table_or_page(&self) -> bool;
 }
 
-/// Safety: the caller must do proper error handling if it's failed to allocate memory
 pub trait MemAlloc {
+    /// Allocates memory according to the given layout.
+    ///
+    /// # Safety
+    ///
+    /// - The `layout` must have a non-zero size.
+    /// - The caller must ensure that the returned pointer is properly deallocated using `deallocate`.
+    /// - If allocation fails, a null pointer is returned; the caller must handle this case.
     unsafe fn allocate(&self, layout: Layout) -> *mut u8 {
         alloc::alloc::alloc(layout)
     }
 
+    /// Deallocates memory at the given pointer and layout.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must have been allocated by `allocate` with the same `layout`.
+    /// - `ptr` must be non-null and properly aligned.
+    /// - The memory at `ptr` must not have been deallocated already.
     unsafe fn deallocate(&self, ptr: *mut u8, layout: Layout) {
         alloc::alloc::dealloc(ptr, layout);
     }

--- a/rmm/src/allocator.rs
+++ b/rmm/src/allocator.rs
@@ -8,6 +8,12 @@ static mut HEAP: [MaybeUninit<u8>; RMM_HEAP_SIZE] = [MaybeUninit::uninit(); RMM_
 #[global_allocator]
 static mut ALLOCATOR: LockedHeap = LockedHeap::empty();
 
+/// Initializes the global allocator with a heap backed by the `HEAP` array.
+///
+/// # Safety
+///
+/// - This function must be called exactly once before any memory allocation occurs.
+///   Calling it multiple times or after allocations have started can lead to undefined behavior.
 pub unsafe fn init() {
     ALLOCATOR.lock().init_from_slice(&mut *addr_of_mut!(HEAP));
 }

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -65,6 +65,14 @@ use core::ptr::addr_of;
 // model checking harnesses do not use this function, instead
 // they use their own entry points marked with #[kani::proof]
 // where slightly adjusted `Monitor` is used
+/// Starts the RMM on the specified CPU with the given memory layout.
+///
+/// # Safety
+///
+/// The caller must ensure that:
+/// - The caller must ensure that `cpu_id` corresponds to a valid and initialized CPU.
+/// - The `layout` must be a valid `PlatformMemoryLayout` appropriate for the platform.
+/// - Calling this function may alter system-level configurations and should be done with caution.
 pub unsafe fn start(cpu_id: usize, layout: PlatformMemoryLayout) {
     setup_mmu_cfg(layout);
     setup_el2();
@@ -183,6 +191,11 @@ unsafe fn setup_mmu_cfg(layout: PlatformMemoryLayout) {
 /// The return value encodes: [rmi::RET_XXX, ret_val1, ret_val2]
 /// In most cases, the function returns [rmi::RET_SUCCESS, _, _]
 /// pagefault returns [rmi::RET_PAGE_FAULT, faulted address, _]
+///
+/// # Safety
+///
+/// - This function alters the processor's execution level by jumping to EL1;
+///   the caller must ensure that the system is in a correct state for this transition.
 #[cfg(not(kani))]
 pub unsafe fn rmm_exit(args: [usize; 4]) -> [usize; 4] {
     let mut ret: [usize; 4] = [0usize; 4];

--- a/rmm/src/realm/context.rs
+++ b/rmm/src/realm/context.rs
@@ -72,12 +72,24 @@ impl Context {
         }
     }
 
+    /// Restores the current execution context from the given `Rec`.
+    ///
+    /// # Safety
+    ///
+    /// - This function modifies processor-specific registers and state;
+    ///   ensure that this is safe in the current execution context.
     pub unsafe fn into_current(rec: &Rec<'_>) {
         TPIDR_EL2.set(rec as *const _ as u64);
         gic::restore_state(rec);
         timer::restore_state(rec);
     }
 
+    /// Saves the current execution context into the given `Rec` record.
+    ///
+    /// # Safety
+    ///
+    /// - This function reads and modifies processor-specific registers and state;
+    ///   ensure that this is appropriate in the current execution context.
     pub unsafe fn from_current(rec: &mut Rec<'_>) {
         gic::save_state(rec);
         timer::save_state(rec);

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -14,7 +14,6 @@ cargo clippy --lib -p islet_rmm -- \
 	-A clippy::let_underscore_lock \
 	-A clippy::manual_range_contains \
 	-A clippy::match_like_matches_macro \
-	-A clippy::missing_safety_doc \
 	-A clippy::new_without_default \
 	-A clippy::redundant_pattern_matching \
 	-A clippy::type_complexity \


### PR DESCRIPTION
This PR
- enables the `missing_safety_doc` rule of clippy.
- adds remain the remaining `Safety` notes.