### PR TITLE
Directly use repositories separated from remote-attestation

### DIFF
--- a/examples/veraison/Makefile
+++ b/examples/veraison/Makefile
@@ -1,8 +1,8 @@
 ROOT = $(shell git rev-parse --show-toplevel)
-ISLET_RA := ${ROOT}/../remote-attestation
-ROCLI = ${ISLET_RA}/tools/rocli
-RSICTL = ${ISLET_RA}/tools/rsictl
+ROCLI = https://github.com/islet-project/rocli.git
+RSICTL = https://github.com/islet-project/rsictl.git
 OUT = ${ROOT}/out/shared
+CONFIG_ARM = --config target.aarch64-unknown-linux-gnu.linker='"aarch64-none-linux-gnu-gcc"' --config target.aarch64-unknown-linux-gnu.rustflags='[ "-C", "target-feature=+crt-static" ]'
 TARGET_X86_64 = x86_64-unknown-linux-gnu
 TARGET_ARM = aarch64-unknown-linux-gnu
 
@@ -13,27 +13,25 @@ all: ${OUT} bin/rocli ${OUT}/bin/rsictl bin/rsictl bin/reliant-party ${OUT}/bin/
 ${OUT}:
 	mkdir -p "${OUT}"
 
-bin/rocli: ${ROCLI} ${ROCLI}/src
-	cargo install --profile release --path "${ROCLI}" --root . --target ${TARGET_X86_64}
+bin/rocli:
+	cargo install --profile release --git "${ROCLI}" --root . --target ${TARGET_X86_64}
 
-${OUT}/bin/rsictl: ${RSICTL} ${RSICTL}/src
-	cargo install --profile release --path "${RSICTL}" --root "${OUT}" --target ${TARGET_ARM}
+${OUT}/bin/rsictl:
+	cargo install ${CONFIG_ARM} --profile release --git "${RSICTL}" --root "${OUT}" --target ${TARGET_ARM}
 
-bin/rsictl: ${RSICTL} ${RSICTL}/src
-	cargo install --profile release --path "${RSICTL}" --root . --target ${TARGET_X86_64}
+bin/rsictl:
+	cargo install --profile release --git "${RSICTL}" --root . --target ${TARGET_X86_64}
 
 bin/reliant-party: reliant-party reliant-party/src
 	cargo install --profile release --path reliant-party --root . --target ${TARGET_X86_64}
 
 ${OUT}/bin/realm-application: realm-application realm-application/src
-	cargo install --profile release --path realm-application --root "${OUT}" --target ${TARGET_ARM}
+	cargo install ${CONFIG_ARM} --profile release --path realm-application --root "${OUT}" --target ${TARGET_ARM}
 
 ${OUT}/root-ca.crt: realm-application/root-ca.crt
 	cp realm-application/root-ca.crt ${OUT}
 
 clean:
-	cargo clean --profile release --manifest-path "${ROCLI}"/Cargo.toml --target ${TARGET_X86_64}
-	cargo clean --profile release --manifest-path "${RSICTL}"/Cargo.toml --target ${TARGET_ARM}
 	cargo clean --profile release --manifest-path reliant-party/Cargo.toml --target ${TARGET_X86_64}
 	cargo clean --profile release --manifest-path realm-application/Cargo.toml --target ${TARGET_ARM}
 	rm -rf bin

--- a/examples/veraison/RUN.md
+++ b/examples/veraison/RUN.md
@@ -16,36 +16,38 @@ The following repos will be used:
 
 * Islet: https://github.com/islet-project/islet that provides:
 
-	* the whole SW/FW stack and scripts for running the emulated environment under the FVP
-	* Islet HES https://github.com/islet-project/islet/tree/main/hes
-	* kvmtool-rim-measurer from https://github.com/islet-project/islet/tree/main/third-party/
+    * the whole SW/FW stack and scripts for running the emulated environment under the FVP
+    * Islet HES https://github.com/islet-project/islet/tree/main/hes
+    * kvmtool-rim-measurer from https://github.com/islet-project/islet/tree/main/third-party/
 
-* Islet Remote Attestation: https://github.com/islet-project/remote-attestation that provides:
+* Various miscelanous tools and libraries for Remote Attestation
 
-	* rocli: https://github.com/islet-project/remote-attestation/tree/main/tools/rocli
-	  Tool for provisioning reference token and CPAK to the Veraison services.
-	* realm-verifier: https://github.com/islet-project/remote-attestation/tree/main/lib/realm-verifier
-      A library for veryfing RIM and REMs with reference values.
-    * ratls: https://github.com/islet-project/remote-attestation/tree/main/lib/ratls
+    * rust-rsi: https://github.com/islet-project/rust-rsi
+      A library implementing token and RSI related functionalities (fetching, parsing).
+    * rsictl: https://github.com/islet-project/rsictl
+      Tool for performing RSI operations from user space.
+    * rocli: https://github.com/islet-project/rocli
+      Tool for provisioning reference token and CPAK to the Veraison services.
+    * ratls: https://github.com/islet-project/ratls
       A library implementing RaTLS protocol for attestation purposes.
-    * rust-rsi: https://github.com/islet-project/remote-attestation/tree/main/lib/rust-rsi
-	  A library implementing token and RSI related functionalities (fetching, parsing).
+    * realm-verifier: https://github.com/islet-project/realm-verifier
+      A library for verifying RIM and REMs with reference values.
+    * veraison-verifier: https://github.com/islet-project/veraison-verifier
+      A library for verifying platform token with reference values using Veraison service.
 
 * veraison: https://github.com/veraison/services
 
 # Preparation
 
-The 3 aforementioned repositories should be checked out on the same level so it
-should look like following:
+Only the Islet repository should be checked manually:
 
     CCA/islet
-	CCA/remote-attestation
 
 Now run `make` inside the `CCA/islet/examples/veraison` directory. This compiles
 some tools that will be used for this demo and places them inside proper
 directories. It also copies the `root-ca.crt` used by `realm-application`.
 
-	CCA/islet/examples/veraison $ make
+    CCA/islet/examples/veraison $ make
 
 The files installed are:
 
@@ -128,7 +130,7 @@ The generated token is saved as the following file:
 Realm measurement is done by generating a json file containing realm information
 that will be fed to realm verifier.
 
-### Using kvmtool-rim-measurer
+### Using kvmtool-rim-measurer (TODO: this needs simplification)
 
 This is performed by a small helper program called `kvmtool-rim-measurer`. It basically
 runs a modified lkvm tool that calculates and displays the RIM
@@ -155,7 +157,8 @@ RIM value is between `[]` characters.
 ### Create a refence measurement values file
 
 Create a `reference.json` file using the commands below (replace the
-`PASTE_THE_OBTAINED_RIM_HEX_STRING_HERE` with the RIM obtained from one of the previous steps:
+`PASTE_THE_OBTAINED_RIM_HEX_STRING_HERE` with the RIM obtained from one of the
+previous steps):
 
 ```
 export RIM="PASTE_THE_OBTAINED_RIM_HEX_STRING_HERE"
@@ -236,9 +239,9 @@ This is how it looks:
     buildroot login: root
 
     # cd /shared
-	shared # ./set-realm-ip.sh
+    shared # ./set-realm-ip.sh
     shared # insmod rsi.ko
-	shared # date 120512002023
+    shared # date 120512002023
 
 # Running and provisioning verification services (Veraison, realm-verifier)
 

--- a/examples/veraison/realm-application/Cargo.toml
+++ b/examples/veraison/realm-application/Cargo.toml
@@ -11,8 +11,8 @@ description = "Realm application for the remote attestation"
 
 [dependencies]
 clap = { version = "*", features = ["derive"] }
-rust-rsi = { git = "https://github.com/islet-project/remote-attestation" }
-ratls = { git = "https://github.com/islet-project/remote-attestation" }
+rust-rsi = { git = "https://github.com/islet-project/rust-rsi" }
+ratls = { git = "https://github.com/islet-project/ratls" }
 
 [profile.release]
 strip = true

--- a/examples/veraison/reliant-party/Cargo.toml
+++ b/examples/veraison/reliant-party/Cargo.toml
@@ -14,8 +14,8 @@ env_logger ="*"
 hex = "*"
 log = "*"
 tinyvec = "*"
-rust-rsi = { git = "https://github.com/islet-project/remote-attestation" }
-ratls = { git = "https://github.com/islet-project/remote-attestation" }
-realm-verifier = { git = "https://github.com/islet-project/remote-attestation" }
-veraison-verifier = { git = "https://github.com/islet-project/remote-attestation" }
+rust-rsi = { git = "https://github.com/islet-project/rust-rsi" }
+ratls = { git = "https://github.com/islet-project/ratls" }
+realm-verifier = { git = "https://github.com/islet-project/realm-verifier" }
+veraison-verifier = { git = "https://github.com/islet-project/veraison-verifier" }
 serde_json = "*"


### PR DESCRIPTION
Update Makefile, compiled tools directly from the git. Update README for the changes, some cosmetics.