### PR TITLE
sdk: Fix to return user_data on the simulated version

### DIFF
--- a/sdk/src/parser.rs
+++ b/sdk/src/parser.rs
@@ -5,9 +5,10 @@ use rust_rsi::{print_token, PlatClaims, RealmClaims};
 pub fn parse(claims: &AttestationClaims) -> Result<(RealmClaims, PlatClaims), Error> {
     cfg_if::cfg_if! {
         if #[cfg(target_arch = "x86_64")] {
-            let realm_claims = RealmClaims::from_raw_claims(
+            let mut realm_claims = RealmClaims::from_raw_claims(
                     &claims.origin.realm_claims.token_claims,
                     &claims.origin.realm_claims.measurement_claims)?;
+            realm_claims.challenge = claims.user_data.clone();
             let plat_claims = PlatClaims::from_raw_claims(
                     &claims.origin.platform_claims.token_claims)?;
             Ok((realm_claims, plat_claims))


### PR DESCRIPTION
This PR fixes [the CI error](https://github.com/islet-project/islet/actions/runs/12064011930).

- SDK should return proper user data which is passed as realm challenge (simulated version)