### PR TITLE
Add a guard page to mitigate stack overflow

### DIFF
--- a/plat/fvp/memory.x
+++ b/plat/fvp/memory.x
@@ -52,13 +52,12 @@ SECTIONS {
     } >REALM_PAS
     __BSS_SIZE__ = SIZEOF(.bss);
 
-    .stacks (NOLOAD) : {
-        __RMM_STACK_START__ = .;
-        KEEP(*(.stack));
-        __RMM_STACK_END__ = .;
-    } >REALM_PAS
-
     __RW_END__ = .;
+
+    .stacks ALIGN(SIZE_4KB) (NOLOAD) : {
+        __RMM_STACK_BASE__ = .;
+        KEEP(*(.stack));
+    } >REALM_PAS
 
     /DISCARD/ : {
         *(.comment*);
@@ -70,4 +69,8 @@ SECTIONS {
         *(.note*);
         *(.plt*);
     }
+
+    __RMM_END__ = .;
+
+    ASSERT((__RMM_END__ < ORIGIN(REALM_PAS) + LENGTH(REALM_PAS)), "REALM_PAS size exceeded!")
 }

--- a/plat/fvp/src/main.rs
+++ b/plat/fvp/src/main.rs
@@ -19,6 +19,7 @@ extern "C" {
     static __RMM_BASE__: u64;
     static __RW_START__: u64;
     static __RW_END__: u64;
+    static __RMM_STACK_BASE__: u64;
 }
 
 #[no_mangle]
@@ -34,6 +35,7 @@ pub unsafe fn main() -> ! {
             rmm_base: &__RMM_BASE__ as *const u64 as u64,
             rw_start: &__RW_START__ as *const u64 as u64,
             rw_end: &__RW_END__ as *const u64 as u64,
+            stack_base: &__RMM_STACK_BASE__ as *const u64 as u64,
             uart_phys: 0x1c0c_0000,
         }
     };

--- a/rmm/src/config.rs
+++ b/rmm/src/config.rs
@@ -7,7 +7,8 @@ pub const PAGE_SIZE: usize = 1 << PAGE_BITS; // 4KiB
 pub const LARGE_PAGE_SIZE: usize = 1024 * 1024 * 2; // 2MiB
 pub const HUGE_PAGE_SIZE: usize = 1024 * 1024 * 1024; // 1GiB
 
-pub const RMM_STACK_SIZE: usize = 1024 * 1024;
+pub const RMM_STACK_GUARD_SIZE: usize = crate::granule::GRANULE_SIZE * 1;
+pub const RMM_STACK_SIZE: usize = 1024 * 1024 - RMM_STACK_GUARD_SIZE;
 pub const RMM_HEAP_SIZE: usize = 16 * 1024 * 1024;
 
 pub const VM_STACK_SIZE: usize = 1 << 15;
@@ -16,9 +17,11 @@ pub const STACK_ALIGN: usize = 16;
 // TODO: Acquire this address properly.
 pub const RMM_SHARED_BUFFER_START: usize = 0xFFBFF000;
 
+#[derive(Debug, Default)]
 pub struct PlatformMemoryLayout {
     pub rmm_base: u64,
     pub rw_start: u64,
     pub rw_end: u64,
+    pub stack_base: u64,
     pub uart_phys: u64,
 }


### PR DESCRIPTION
This PR makes the first page of stack as the guard page (unmapped) to mitigate stack overflow.

## AS-IS
The RMM memory layout assigns the CPU stacks in a continuous manner, which can lead to stack overflow issues spilling over between CPUs. 

```
 | core 7 stack | core 6 stack | ... | core 0 stack |
 ^                 
stack_start 
(low addr)      >>>      (high addr)
```

## TO-BE
To mitigate this, the first page of each stack is reserved as a guard page.
```
 | guard_page | core 0 stack | guard_page | core 1 stack | ... | core 7 stack |
              ^                    
             stack_start 
(low addr)      >>>      (high addr)
```