### PR TITLE
Realm FPU context

### DIFF
--- a/lib/armv9a/Cargo.toml
+++ b/lib/armv9a/Cargo.toml
@@ -3,3 +3,7 @@ name = "armv9a"
 version = "0.0.1"
 authors = ["Islet Contributors"]
 edition = "2021"
+
+[dependencies]
+aarch64-cpu = { version = "10.0.0" }
+tock-registers = { version = "0.9.0" }

--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -1,3 +1,20 @@
+#![allow(unused_attributes)]
+
+#[macro_use]
+mod macros;
+
+mod cptr_el2;
+mod id_aa64pfr1_el1;
+mod smcr_el2;
+mod zcr_el1;
+mod zcr_el2;
+
+pub use cptr_el2::CPTR_EL2;
+pub use id_aa64pfr1_el1::ID_AA64PFR1_SME_EL1;
+pub use smcr_el2::SMCR_EL2;
+pub use zcr_el1::ZCR_EL1;
+pub use zcr_el2::ZCR_EL2;
+
 use crate::bits_in_reg;
 
 define_bits!(

--- a/lib/armv9a/src/regs/cptr_el2.rs
+++ b/lib/armv9a/src/regs/cptr_el2.rs
@@ -1,0 +1,61 @@
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields,
+};
+
+register_bitfields! {u64,
+    pub CPTR_EL2 [
+        // Trap accesses to CPACR_EL1 from EL1 to EL2,
+        TCPAC  OFFSET(31) NUMBITS(1) [],
+        // Trap Activity Monitor access from EL1 and EL0.
+        TAM  OFFSET(30) NUMBITS(1) [],
+        // Traps System register accesses to all implemented trace registers
+        TTA OFFSET(20) NUMBITS(1) [],
+        // Traps execution of SME instructions
+        TSM OFFSET(12) NUMBITS(1) [],
+        // Traps execution of Advanced SIMD and floating-point instructions
+        TFP OFFSET(10) NUMBITS(1) [],
+        // Traps execution of SVE instructions
+        TZ OFFSET(8) NUMBITS(1) [],
+/*
+        // Traps System register accesses to all implemented trace registers
+        TTA OFFSET(28) NUMBITS(1) [],
+        // Traps execution at EL2, EL1, and EL0 of SME instructions
+        SMEN OFFSET(24) NUMBITS(2) [
+            TrapAll = 0b00,
+            TrapE0 = 0b01,
+            TrapNone = 0b11,
+        ],
+        // Traps execution of SIMD and FPU
+        FPEN OFFSET(20) NUMBITS(2) [
+            TrapAll = 0b00,
+            TrapE0 = 0b01,
+            TrapNone = 0b11,
+        ],
+        // Traps execution of non-streaming SVE
+        ZEN OFFSET(16) NUMBITS(2) [
+            TrapAll = 0b00,
+            TrapE0 = 0b01,
+            TrapNone = 0b11,
+        ]
+*/
+    ]
+}
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = CPTR_EL2::Register;
+
+    sys_coproc_read_raw!(u64, "CPTR_EL2", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = CPTR_EL2::Register;
+
+    sys_coproc_write_raw!(u64, "CPTR_EL2", "x");
+}
+
+pub const CPTR_EL2: Reg = Reg {};

--- a/lib/armv9a/src/regs/id_aa64pfr1_el1.rs
+++ b/lib/armv9a/src/regs/id_aa64pfr1_el1.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (c) 2024 by the author(s)
+//
+// Author(s):
+//   - Sangwan Kwon <sangwan.kwon@samsung.com>
+
+//! AArch64 Processor Feature Register 1 - EL1
+//!
+//! Provides additional information about implemented PE features in AArch64 state.
+
+use tock_registers::{interfaces::Readable, register_bitfields};
+
+register_bitfields! {u64,
+    pub ID_AA64PFR1_SME_EL1 [
+        /// Support for the Scalable Matrix Extension.
+        SME OFFSET(24) NUMBITS(4) [],
+        /// Support for the Memory Tagging Extension.
+        MTE OFFSET(8) NUMBITS(4) [],
+    ]
+}
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = ID_AA64PFR1_SME_EL1::Register;
+
+    sys_coproc_read_raw!(u64, "ID_AA64PFR1_EL1", "x");
+}
+
+pub const ID_AA64PFR1_SME_EL1: Reg = Reg {};

--- a/lib/armv9a/src/regs/macros.rs
+++ b/lib/armv9a/src/regs/macros.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+// Copyright (c) 2018-2023 by the author(s)
+//
+// Author(s):
+//   - Andre Richter <andre.o.richter@gmail.com>
+
+macro_rules! __read_raw {
+    ($width:ty, $asm_instr:tt, $asm_reg_name:tt, $asm_width:tt) => {
+        /// Reads the raw bits of the CPU register.
+        #[inline]
+        fn get(&self) -> $width {
+            match () {
+                #[cfg(target_arch = "aarch64")]
+                () => {
+                    let reg;
+                    unsafe {
+                        core::arch::asm!(concat!($asm_instr, " {reg:", $asm_width, "}, ", $asm_reg_name), reg = out(reg) reg, options(nomem, nostack));
+                    }
+                    reg
+                }
+
+                #[cfg(not(target_arch = "aarch64"))]
+                () => unimplemented!(),
+            }
+        }
+    };
+}
+
+macro_rules! __write_raw {
+    ($width:ty, $asm_instr:tt, $asm_reg_name:tt, $asm_width:tt) => {
+        /// Writes raw bits to the CPU register.
+        #[cfg_attr(not(target_arch = "aarch64"), allow(unused_variables))]
+        #[inline]
+        fn set(&self, value: $width) {
+            match () {
+                #[cfg(target_arch = "aarch64")]
+                () => {
+                    unsafe {
+                        core::arch::asm!(concat!($asm_instr, " ", $asm_reg_name, ", {reg:", $asm_width, "}"), reg = in(reg) value, options(nomem, nostack))
+                    }
+                }
+
+                #[cfg(not(target_arch = "aarch64"))]
+                () => unimplemented!(),
+            }
+        }
+    };
+}
+
+/// Raw read from system coprocessor registers.
+macro_rules! sys_coproc_read_raw {
+    ($width:ty, $asm_reg_name:tt, $asm_width:tt) => {
+        __read_raw!($width, "mrs", $asm_reg_name, $asm_width);
+    };
+}
+
+/// Raw write to system coprocessor registers.
+macro_rules! sys_coproc_write_raw {
+    ($width:ty, $asm_reg_name:tt, $asm_width:tt) => {
+        __write_raw!($width, "msr", $asm_reg_name, $asm_width);
+    };
+}
+
+#[macro_export]
+/// Raw read from (ordinary) registers.
+macro_rules! read_raw {
+    ($width:ty, $asm_reg_name:tt, $asm_width:tt) => {
+        __read_raw!($width, "mov", $asm_reg_name, $asm_width);
+    };
+}
+
+#[macro_export]
+/// Raw write to (ordinary) registers.
+macro_rules! write_raw {
+    ($width:ty, $asm_reg_name:tt, $asm_width:tt) => {
+        __write_raw!($width, "mov", $asm_reg_name, $asm_width);
+    };
+}

--- a/lib/armv9a/src/regs/smcr_el2.rs
+++ b/lib/armv9a/src/regs/smcr_el2.rs
@@ -1,0 +1,32 @@
+//! Realm Management Monitor Configuration Register - EL2
+
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields,
+};
+
+register_bitfields! {u64,
+    pub SMCR_EL2 [
+        RAZWI   OFFSET(4) NUMBITS(5) [],
+
+        LEN OFFSET(0) NUMBITS(4) []
+    ]
+}
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = SMCR_EL2::Register;
+
+    sys_coproc_read_raw!(u64, "SMCR_EL2", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = SMCR_EL2::Register;
+
+    sys_coproc_write_raw!(u64, "SMCR_EL2", "x");
+}
+
+pub const SMCR_EL2: Reg = Reg {};

--- a/lib/armv9a/src/regs/zcr_el1.rs
+++ b/lib/armv9a/src/regs/zcr_el1.rs
@@ -1,0 +1,34 @@
+//! Realm Management Monitor Configuration Register - EL1
+
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields,
+};
+
+register_bitfields! {u64,
+    pub ZCR_EL1 [
+        RAZWI   OFFSET(4) NUMBITS(5) [],
+
+        LEN OFFSET(0) NUMBITS(4) []
+    ]
+}
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = ZCR_EL1::Register;
+
+    //sys_coproc_read_raw!(u64, "ZCR_EL1", "x");
+    sys_coproc_read_raw!(u64, "S3_0_C1_C2_0", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = ZCR_EL1::Register;
+
+    //sys_coproc_write_raw!(u64, "ZCR_EL1", "x");
+    sys_coproc_write_raw!(u64, "S3_0_C1_C2_0", "x");
+}
+
+pub const ZCR_EL1: Reg = Reg {};

--- a/lib/armv9a/src/regs/zcr_el2.rs
+++ b/lib/armv9a/src/regs/zcr_el2.rs
@@ -1,0 +1,34 @@
+//! Realm Management Monitor Configuration Register - EL2
+
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields,
+};
+
+register_bitfields! {u64,
+    pub ZCR_EL2 [
+        RAZWI   OFFSET(4) NUMBITS(5) [],
+
+        LEN OFFSET(0) NUMBITS(4) []
+    ]
+}
+
+pub struct Reg;
+
+impl Readable for Reg {
+    type T = u64;
+    type R = ZCR_EL2::Register;
+
+    //sys_coproc_read_raw!(u64, "ZCR_EL2", "x");
+    sys_coproc_read_raw!(u64, "S3_4_C1_C2_0", "x");
+}
+
+impl Writeable for Reg {
+    type T = u64;
+    type R = ZCR_EL2::Register;
+
+    //sys_coproc_write_raw!(u64, "ZCR_EL2", "x");
+    sys_coproc_write_raw!(u64, "S3_4_C1_C2_0", "x");
+}
+
+pub const ZCR_EL2: Reg = Reg {};

--- a/plat/fvp/.cargo/config.toml
+++ b/plat/fvp/.cargo/config.toml
@@ -5,5 +5,6 @@ target = "aarch64-unknown-none-softfloat"
 rustflags = [
   "-C", "link-args=-Tplat/fvp/memory.x",
   "-C", "target-feature=+ecv",
+  "-C", "target-feature=+sme",
   "-C", "target-feature=+tlb-rmi"
 ]

--- a/rmm/.cargo/config.toml
+++ b/rmm/.cargo/config.toml
@@ -2,5 +2,6 @@
 target = "aarch64-unknown-none-softfloat"
 rustflags = [
   "-C", "target-feature=+ecv",
+  "-C", "target-feature=+sme",
   "-C", "target-feature=+tlb-rmi"
 ]

--- a/rmm/src/exception/trap.rs
+++ b/rmm/src/exception/trap.rs
@@ -236,6 +236,7 @@ pub extern "C" fn handle_lower_exception(
                 rec.context.simd.is_used = true;
                 unsafe {
                     if rec.context.simd.is_saved {
+                        #[cfg(not(any(miri, test)))]
                         match Syndrome::from(esr) {
                             Syndrome::FPU => simd::restore_fpu(&rec.context.simd.fpu),
                             Syndrome::SVE | Syndrome::SME => {

--- a/rmm/src/exception/trap/syndrome.rs
+++ b/rmm/src/exception/trap/syndrome.rs
@@ -42,6 +42,9 @@ pub enum Syndrome {
     SMC,
     SysRegInst,
     WFX,
+    FPU,
+    SVE,
+    SME,
     Other(u32),
 }
 
@@ -50,11 +53,14 @@ impl From<u32> for Syndrome {
         match (origin >> ESR_EL2::EC.shift) & ESR_EL2::EC.mask as u32 {
             0b00_0000 => Syndrome::Unknown,
             0b00_0001 => Syndrome::WFX,
+            0b00_0111 => Syndrome::FPU,
             0b01_0010 => Syndrome::HVC,
             0b01_0110 => Syndrome::HVC,
             0b01_0011 => Syndrome::SMC,
             0b01_0111 => Syndrome::SMC,
             0b01_1000 => Syndrome::SysRegInst,
+            0b01_1001 => Syndrome::SVE,
+            0b01_1101 => Syndrome::SME,
             0b10_0000 => {
                 debug!("Instruction Abort from a lower Exception level");
                 Syndrome::InstructionAbort(Fault::from(origin))

--- a/rmm/src/exception/vectors.s
+++ b/rmm/src/exception/vectors.s
@@ -52,8 +52,8 @@
 	stp x1, x2, [x18, #REC_GP_REGS + 8 * 31]
 .endm
 
-.global restore_all_from_rec_and_run
-restore_all_from_rec_and_run:
+.global restore_all_from_rec
+restore_all_from_rec:
 	mrs x0, tpidr_el2
 
 	/* Restore system registers */
@@ -117,18 +117,8 @@ restore_all_from_rec_and_run:
 	/* TODO: invalidate TLB */
 
 	/* Intentional fallthrough */
-.global restore_nonvolatile_from_rec_and_run
-restore_nonvolatile_from_rec_and_run:
-	/* Restore non-volatile registers. */
-	ldp x19, x20, [x0, #REC_GP_REGS + 8 * 19]
-	ldp x21, x22, [x0, #REC_GP_REGS + 8 * 21]
-	ldp x23, x24, [x0, #REC_GP_REGS + 8 * 23]
-	ldp x25, x26, [x0, #REC_GP_REGS + 8 * 25]
-	ldp x27, x28, [x0, #REC_GP_REGS + 8 * 27]
-
-	/* Intentional fallthrough */
-.global restore_volatile_from_rec_and_run
-restore_volatile_from_rec_and_run:
+.global restore_volatile_from_rec
+restore_volatile_from_rec:
 	ldp x4, x5, [x0, #REC_GP_REGS + 8 * 4]
 	ldp x6, x7, [x0, #REC_GP_REGS + 8 * 6]
 	ldp x8, x9, [x0, #REC_GP_REGS + 8 * 8]
@@ -136,8 +126,13 @@ restore_volatile_from_rec_and_run:
 	ldp x12, x13, [x0, #REC_GP_REGS + 8 * 12]
 	ldp x14, x15, [x0, #REC_GP_REGS + 8 * 14]
 	ldp x16, x17, [x0, #REC_GP_REGS + 8 * 16]
-	ldr x18, [x0, #REC_GP_REGS + 8 * 18]
-	ldp x29, x30, [x0, #REC_GP_REGS + 8 * 29]
+    ldp x18, x19, [x0, #REC_GP_REGS + 8 * 18]
+	ldp x20, x21, [x0, #REC_GP_REGS + 8 * 20]
+	ldp x22, x23, [x0, #REC_GP_REGS + 8 * 22]
+	ldp x24, x25, [x0, #REC_GP_REGS + 8 * 24]
+	ldp x26, x27, [x0, #REC_GP_REGS + 8 * 26]
+	ldp x28, x29, [x0, #REC_GP_REGS + 8 * 28]
+	ldr x30, [x0, #REC_GP_REGS + 8 * 30]
 
 	ldp x1, x2, [x0, #REC_GP_REGS + 8 * 31]
 	msr elr_el2, x1
@@ -200,7 +195,7 @@ restore_volatile_from_stack_and_return:
 	cbnz x0, rmm_enter
 
 	mrs x0, tpidr_el2
-	b restore_nonvolatile_from_rec_and_run
+	b restore_volatile_from_rec
 .endm
 
 .global rmm_enter
@@ -319,7 +314,7 @@ rmm_exit:
 	str xzr, [SP, #-8]!
 	str xzr, [SP, #-8]!
 
-	b restore_all_from_rec_and_run
+	b restore_all_from_rec
 
 .align 11
 .global vectors

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -27,6 +27,7 @@ pub mod realm;
 pub mod rec;
 pub mod rmi;
 pub mod rsi;
+pub mod simd;
 #[cfg(feature = "stat")]
 pub mod stat;
 #[cfg(any(test, miri))]

--- a/rmm/src/realm/context.rs
+++ b/rmm/src/realm/context.rs
@@ -2,6 +2,8 @@ use super::timer;
 use crate::gic;
 use crate::rec::Rec;
 use crate::rmi::error::Error;
+use crate::simd;
+use crate::simd::SimdRegister;
 
 use aarch64_cpu::registers::*;
 
@@ -14,7 +16,7 @@ pub struct Context {
     pub sys_regs: SystemRegister,
     pub gic_state: GICRegister,
     pub timer: TimerRegister,
-    pub fp_regs: [u128; 32],
+    pub simd: SimdRegister,
 }
 
 pub struct RegOffset;
@@ -82,6 +84,7 @@ impl Context {
         TPIDR_EL2.set(rec as *const _ as u64);
         gic::restore_state(rec);
         timer::restore_state(rec);
+        simd::restore_state(rec);
     }
 
     /// Saves the current execution context into the given `Rec` record.
@@ -93,6 +96,7 @@ impl Context {
     pub unsafe fn from_current(rec: &mut Rec<'_>) {
         gic::save_state(rec);
         timer::save_state(rec);
+        simd::save_state(rec);
     }
 }
 

--- a/rmm/src/realm/context.rs
+++ b/rmm/src/realm/context.rs
@@ -84,6 +84,7 @@ impl Context {
         TPIDR_EL2.set(rec as *const _ as u64);
         gic::restore_state(rec);
         timer::restore_state(rec);
+        #[cfg(not(any(test, miri)))]
         simd::restore_state(rec);
     }
 
@@ -96,6 +97,7 @@ impl Context {
     pub unsafe fn from_current(rec: &mut Rec<'_>) {
         gic::save_state(rec);
         timer::save_state(rec);
+        #[cfg(not(any(test, miri)))]
         simd::save_state(rec);
     }
 }

--- a/rmm/src/rec.rs
+++ b/rmm/src/rec.rs
@@ -6,6 +6,7 @@ use crate::rmi::error::Error;
 use crate::rmi::rec::params::NR_AUX;
 use crate::rmm_exit;
 use crate::rsi::attestation::MAX_CHALLENGE_SIZE;
+use crate::simd;
 
 use aarch64_cpu::registers::*;
 
@@ -120,6 +121,7 @@ impl Rec<'_> {
         self.aux.copy_from_slice(&aux);
         timer::init_timer(self);
         gic::init_gic(self);
+        simd::init_simd(self)?;
 
         Ok(())
     }

--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -1,45 +1,35 @@
 use crate::event::RmiHandle;
 use crate::listen;
 use crate::rmi;
+use armv9a::{define_bitfield, define_bits, define_mask};
 
 extern crate alloc;
 
-const S2SZ_SHIFT: usize = 0;
-const S2SZ_WIDTH: usize = 8;
-const S2SZ_VALUE: usize = 48;
+define_bits!(
+    FeatureReg0,
+    HASH_SHA_512[29 - 29],
+    HASH_SHA_256[28 - 28],
+    PMU_NUM_CTRS[27 - 23],
+    PMU_EN[22 - 22],
+    NUM_WPS[21 - 18],
+    NUM_BPS[17 - 14],
+    SVE_VL[13 - 10],
+    SVE_EN[9 - 9],
+    LPA2[8 - 8],
+    S2SZ[7 - 0]
+);
 
-const LPA2_SHIFT: usize = 8;
-#[allow(unused)]
-const LPA2_WIDTH: usize = 1;
-const LPA2_VALUE: usize = 0;
+const S2SZ_VALUE: u64 = 48;
+const LPA2_VALUE: u64 = 0;
+const PMU_EN_VALUE: u64 = NOT_SUPPORTED;
+const PMU_NUM_CTRS_VALUE: u64 = 0;
+const HASH_SHA_256_VALUE: u64 = SUPPORTED;
+const HASH_SHA_512_VALUE: u64 = SUPPORTED;
 
-const PMU_EN_SHIFT: usize = 22;
-const PMU_EN_WIDTH: usize = 1;
-const PMU_EN_VALUE: usize = NOT_SUPPORTED;
-
-const PMU_NUM_CTRS_SHIFT: usize = 23;
-const PMU_NUM_CTRS_WIDTH: usize = 5;
-const PMU_NUM_CTRS_VALUE: usize = 0;
-
-const HASH_SHA_256_SHIFT: usize = 28;
-const HASH_SHA_256_VALUE: usize = SUPPORTED;
-
-const HASH_SHA_512_SHIFT: usize = 29;
-const HASH_SHA_512_VALUE: usize = SUPPORTED;
-
-const NOT_SUPPORTED: usize = 0;
-const SUPPORTED: usize = 1;
+const NOT_SUPPORTED: u64 = 0;
+const SUPPORTED: u64 = 1;
 
 const FEATURE_REGISTER_0_INDEX: usize = 0;
-
-fn extract(reg: usize, shift: usize, width: usize) -> usize {
-    let mask = mask(shift, width);
-    (reg << (mask.trailing_zeros())) & mask
-}
-
-fn mask(shift: usize, width: usize) -> usize {
-    (!0usize >> (64usize - width)) << shift
-}
 
 pub fn set_event_handler(rmi: &mut RmiHandle) {
     listen!(rmi, rmi::FEATURES, |arg, ret, _| {
@@ -48,41 +38,30 @@ pub fn set_event_handler(rmi: &mut RmiHandle) {
             return Ok(());
         }
 
-        let mut feat_reg0: usize = 0;
-        feat_reg0 |= S2SZ_VALUE << S2SZ_SHIFT;
-        feat_reg0 |= LPA2_VALUE << LPA2_SHIFT;
-        feat_reg0 |= PMU_EN_VALUE << PMU_EN_SHIFT;
-        feat_reg0 |= PMU_NUM_CTRS_VALUE << PMU_NUM_CTRS_SHIFT;
-        feat_reg0 |= HASH_SHA_256_VALUE << HASH_SHA_256_SHIFT;
-        feat_reg0 |= HASH_SHA_512_VALUE << HASH_SHA_512_SHIFT;
+        let mut feat_reg0 = FeatureReg0::new(0);
+        feat_reg0
+            .set_masked_value(FeatureReg0::S2SZ, S2SZ_VALUE)
+            .set_masked_value(FeatureReg0::LPA2, LPA2_VALUE)
+            .set_masked_value(FeatureReg0::PMU_EN, PMU_EN_VALUE)
+            .set_masked_value(FeatureReg0::PMU_NUM_CTRS, PMU_NUM_CTRS_VALUE)
+            .set_masked_value(FeatureReg0::HASH_SHA_256, HASH_SHA_256_VALUE)
+            .set_masked_value(FeatureReg0::HASH_SHA_512, HASH_SHA_512_VALUE);
 
-        ret[1] = feat_reg0;
-        debug!("rmi::FEATURES ret:{:X}", feat_reg0);
+        ret[1] = feat_reg0.get() as usize;
+        debug!("rmi::FEATURES ret:{:X}", feat_reg0.get());
         Ok(())
     });
 }
 
-pub fn ipa_bits(feat_reg0: usize) -> usize {
-    extract(feat_reg0, S2SZ_SHIFT, S2SZ_WIDTH)
+pub fn ipa_bits(val: usize) -> usize {
+    let feat_reg0 = FeatureReg0::new(val as u64);
+    feat_reg0.get_masked_value(FeatureReg0::S2SZ) as usize
 }
 
 //TODO: locate validate() in armv9a to check against AA64MMFR_EL1 register
-pub fn validate(feat_reg0: usize) -> bool {
-    const MIN_IPA_SIZE: usize = 32;
-    let s2sz = extract(feat_reg0, S2SZ_SHIFT, S2SZ_WIDTH);
+pub fn validate(s2sz: u64) -> bool {
+    const MIN_IPA_SIZE: u64 = 32;
     if !(MIN_IPA_SIZE..=S2SZ_VALUE).contains(&s2sz) {
-        return false;
-    }
-
-    if extract(feat_reg0, S2SZ_SHIFT, S2SZ_WIDTH) > S2SZ_VALUE {
-        return false;
-    }
-
-    // TODO: Add a check for LPA2 flag with AA64MMFR_EL1 reigster after refactoring
-
-    if extract(feat_reg0, PMU_EN_SHIFT, PMU_EN_WIDTH) == SUPPORTED
-        && extract(feat_reg0, PMU_NUM_CTRS_SHIFT, PMU_NUM_CTRS_WIDTH) != PMU_NUM_CTRS_VALUE
-    {
         return false;
     }
 

--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -53,15 +53,10 @@ pub fn set_event_handler(rmi: &mut RmiHandle) {
     });
 }
 
-pub fn ipa_bits(val: usize) -> usize {
-    let feat_reg0 = FeatureReg0::new(val as u64);
-    feat_reg0.get_masked_value(FeatureReg0::S2SZ) as usize
-}
-
 //TODO: locate validate() in armv9a to check against AA64MMFR_EL1 register
-pub fn validate(s2sz: u64) -> bool {
-    const MIN_IPA_SIZE: u64 = 32;
-    if !(MIN_IPA_SIZE..=S2SZ_VALUE).contains(&s2sz) {
+pub fn validate(s2sz: usize) -> bool {
+    const MIN_IPA_SIZE: usize = 32;
+    if !(MIN_IPA_SIZE..=S2SZ_VALUE as usize).contains(&s2sz) {
         return false;
     }
 

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -97,6 +97,8 @@ pub fn set_event_handler(rmi: &mut RmiHandle) {
                 params.ipa_bits(),
                 params.rtt_level_start as isize,
                 params.rpv,
+                params.sve_en(),
+                params.sve_vl as u64,
             )
         })?;
 

--- a/rmm/src/simd.rs
+++ b/rmm/src/simd.rs
@@ -84,6 +84,7 @@ lazy_static! {
         let mut sme_en: bool = false;
 
         trace!("Reading simd features");
+        #[cfg(not(any(test, miri)))]
         if ID_AA64PFR0_EL1.is_set(ID_AA64PFR0_EL1::SVE) {
             trace!("SVE is set");
             // Get effective vl
@@ -101,6 +102,7 @@ lazy_static! {
         }
 
         // init sme
+        #[cfg(not(any(test, miri)))]
         if ID_AA64PFR1_SME_EL1.is_set(ID_AA64PFR1_SME_EL1::SME) {
             trace!("SME is set");
             // Find the architecturally permitted SVL
@@ -258,6 +260,7 @@ pub fn save_state(rec: &mut Rec<'_>) {
         rec_simd.sve.zcr_el2 = ZCR_EL2.get();
         rec_simd.sve.zcr_el12 = ZCR_EL1.get();
         ZCR_EL2.set(ns_simd.sve.zcr_el2);
+        unimplemented!();
     } else {
         unsafe {
             if rec_simd.is_used {

--- a/rmm/src/simd.rs
+++ b/rmm/src/simd.rs
@@ -1,0 +1,286 @@
+use aarch64_cpu::registers::ID_AA64PFR0_EL1;
+use aarch64_cpu::registers::{Readable, Writeable};
+use armv9a::regs::{CPTR_EL2, ID_AA64PFR1_SME_EL1, SMCR_EL2, ZCR_EL1, ZCR_EL2};
+use core::arch::asm;
+use core::array::from_fn;
+use lazy_static::lazy_static;
+use spin::mutex::Mutex;
+
+use crate::config::NUM_OF_CPU;
+use crate::cpu::get_cpu_id;
+use crate::realm::rd::Rd;
+use crate::rec::Rec;
+use crate::rmi::error::Error;
+
+// Vector length (VL) = size of a Z-register in bytes
+// Vector quadwords (VQ) = size of a Z-register in units of 128 bits
+// Minimum length of a SVE vector: 128 bits
+const ZCR_EL2_LEN_WIDTH: u64 = 4;
+const SVE_VQ_ARCH_MAX: u64 = (1 << ZCR_EL2_LEN_WIDTH) - 1;
+const QUARD_WORD: u64 = 128;
+
+#[derive(Default, Debug)]
+// SIMD configuration structure
+pub struct SimdConfig {
+    // SVE enabled flag
+    pub sve_en: bool,
+
+    // SVE vector length represented in quads
+    pub sve_vq: u64,
+
+    // SME enabled flag
+    pub sme_en: bool,
+}
+
+// SIMD context structure
+#[derive(Default, Debug)]
+pub struct SimdRegister {
+    pub is_used: bool,
+    pub is_saved: bool,
+
+    pub cfg: SimdConfig,
+    // EL2 trap register for this context
+    pub cptr_el2: u64,
+    // SME specific Streaming vector control register
+    pub svcr: u64,
+    // SIMD data registers
+    pub fpu: FpuRegs,
+    pub sve: SveRegs,
+}
+
+// FPU registers
+const NUM_FPU_REGS: usize = 32;
+#[derive(Default, Debug)]
+pub struct FpuRegs {
+    pub q: [u128; NUM_FPU_REGS],
+    // SIMD related control and status sysregs
+    pub fpsr: u64,
+    pub fpcr: u64,
+}
+
+// SVE registers
+const NUM_VECTOR_REGS: usize = 32;
+const NUM_PREDICATE_REGS: usize = 16;
+#[derive(Default, Debug)]
+pub struct SveRegs {
+    // lower 128bits of each z register are shared with v
+    // implementation-defined lengh: 128bits~2048bits. zcr-el2에서 얻어와야...
+    pub z: [u128; NUM_VECTOR_REGS],
+    // Each predicate register is 1/8 of the Zx length.
+    pub p: [u16; NUM_PREDICATE_REGS],
+    pub ffr: u64,
+    pub zcr_el2: u64,
+    pub zcr_el12: u64,
+}
+
+lazy_static! {
+    // TODO: storing ns simd context should be in the ns world, not in the realm world.
+    static ref NS_SIMD: [Mutex<SimdRegister>; NUM_OF_CPU] = from_fn(|_| Mutex::new(SimdRegister::default()));
+    // Global SIMD configuration
+    static ref SIMD_CONFIG: SimdConfig =  {
+        // Initalize SVE
+        let mut sve_en: bool = false;
+        let mut sve_vq: u64 = 0;
+        let mut sme_en: bool = false;
+
+        trace!("Reading simd features");
+        if ID_AA64PFR0_EL1.is_set(ID_AA64PFR0_EL1::SVE) {
+            trace!("SVE is set");
+            // Get effective vl
+            //let _e_vl = ZCR_EL2.read(ZCR_EL2::LEN);
+            // Set to maximum
+            ZCR_EL2.write(ZCR_EL2::LEN.val(SVE_VQ_ARCH_MAX));
+            // Get vl in bytes
+            let vl_b: u64;
+            unsafe {
+                asm!("rdvl {}, #1", out(reg) vl_b);
+            }
+            sve_vq = ((vl_b << 3)/ QUARD_WORD) - 1;
+            sve_en = true;
+            trace!("sve_vq={:?}", sve_vq);
+        }
+
+        // init sme
+        if ID_AA64PFR1_SME_EL1.is_set(ID_AA64PFR1_SME_EL1::SME) {
+            trace!("SME is set");
+            // Find the architecturally permitted SVL
+            SMCR_EL2.write(SMCR_EL2::RAZWI.val(SMCR_EL2::RAZWI.mask) + SMCR_EL2::LEN.val(SMCR_EL2::LEN.mask));
+            let raz = SMCR_EL2.read(SMCR_EL2::RAZWI);
+            let len = SMCR_EL2.read(SMCR_EL2::LEN);
+            let sme_svq_arch_max = (raz << 4) + len;
+            trace!("sme_svq_arch_max={:?}", sme_svq_arch_max);
+
+            assert!(sme_svq_arch_max <= SVE_VQ_ARCH_MAX);
+            sme_en = true;
+        }
+
+        SimdConfig {
+            sve_en,
+            sve_vq,
+            sme_en,
+        }
+    };
+}
+
+// TODO: Save according to the hint in FID with SMCCCv1.3 or v1.4
+
+// SIMD context initialization function
+pub fn init_simd(rec: &mut Rec<'_>) -> Result<(), Error> {
+    let raw_ptr: *const Rd = rec.owner()? as *const Rd;
+    let rd: &Rd = unsafe { raw_ptr.as_ref().expect("REASON") }; // FIXME
+    let simd_cfg = rd.simd_config();
+
+    let mut zcr_el2: u64 = 0;
+    let mut svcr: u64 = 0;
+
+    rec.context.simd.is_used = false;
+    rec.context.simd.is_saved = false;
+    rec.context.simd.cfg.sve_en = simd_cfg.sve_en;
+    rec.context.simd.cfg.sve_vq = simd_cfg.sve_vq;
+    rec.context.simd.cfg.sme_en = simd_cfg.sme_en;
+
+    // Initialize SVE related fields and config registers
+    if simd_cfg.sve_en {
+        zcr_el2 = ZCR_EL2::LEN.val(simd_cfg.sve_vq).value;
+    }
+    if simd_cfg.sme_en {
+        svcr = 0;
+    }
+
+    let simd_regs = &mut rec.context.simd;
+    // Note: As islet-rmm doesn't enable VHE in the realm world as following,
+    // HCR_EL2.E2H=0, HCR_EL2.TGE=0
+    // the layout of CPTR_EL2 for non E2H is used.
+    simd_regs.cptr_el2 =
+        (CPTR_EL2::TAM::SET + CPTR_EL2::TSM::SET + CPTR_EL2::TFP::SET + CPTR_EL2::TZ::SET).value;
+    simd_regs.sve.zcr_el2 = zcr_el2;
+    simd_regs.svcr = svcr;
+    Ok(())
+}
+
+/// # Safety
+///
+/// Use neon only for (re)storing Rec's simd context
+#[target_feature(enable = "neon")]
+unsafe fn save_fpu(fpu: &mut FpuRegs) {
+    let fpsr: u64;
+    let fpcr: u64;
+    let addr_q: u64 = fpu.q.as_ptr() as u64;
+    unsafe {
+        asm!(
+        "stp q0, q1, [{addr_q}]",
+        "stp q2, q3, [{addr_q}, #32]",
+        "stp q4, q5, [{addr_q}, #64]",
+        "stp q6, q7, [{addr_q}, #96]",
+        "stp q8, q9, [{addr_q}, #128]",
+        "stp q10, q11, [{addr_q}, #160]",
+        "stp q12, q13, [{addr_q}, #192]",
+        "stp q14, q15, [{addr_q}, #224]",
+        "stp q16, q17, [{addr_q}, #256]",
+        "stp q18, q19, [{addr_q}, #288]",
+        "stp q20, q21, [{addr_q}, #320]",
+        "stp q22, q23, [{addr_q}, #352]",
+        "stp q24, q25, [{addr_q}, #384]",
+        "stp q26, q27, [{addr_q}, #416]",
+        "stp q28, q29, [{addr_q}, #448]",
+        "stp q30, q31, [{addr_q}, #480]",
+        "mrs {fpsr}, fpsr",
+        "mrs {fpcr}, fpcr",
+        addr_q = in(reg) addr_q,
+        fpsr = out(reg) fpsr,
+        fpcr = out(reg) fpcr,
+        );
+    }
+    fpu.fpsr = fpsr;
+    fpu.fpcr = fpcr;
+}
+
+/// # Safety
+///
+/// Use neon only for (re)storing Rec's simd context
+#[target_feature(enable = "neon")]
+pub unsafe fn restore_fpu(fpu: &FpuRegs) {
+    let addr_q: u64 = fpu.q.as_ptr() as u64;
+    unsafe {
+        asm!(
+             "ldp q0, q1, [x0]",
+             "ldp q2, q3, [{addr_q}, #32]",
+             "ldp q4, q5, [{addr_q}, #64]",
+             "ldp q6, q7, [{addr_q}, #96]",
+             "ldp q8, q9, [{addr_q}, #128]",
+             "ldp q10, q11, [{addr_q}, #160]",
+             "ldp q12, q13, [{addr_q}, #192]",
+             "ldp q14, q15, [{addr_q}, #224]",
+             "ldp q16, q17, [{addr_q}, #256]",
+             "ldp q18, q19, [{addr_q}, #288]",
+             "ldp q20, q21, [{addr_q}, #320]",
+             "ldp q22, q23, [{addr_q}, #352]",
+             "ldp q24, q25, [{addr_q}, #384]",
+             "ldp q26, q27, [{addr_q}, #416]",
+             "ldp q28, q29, [{addr_q}, #448]",
+             "ldp q30, q31, [{addr_q}, #480]",
+             "msr fpsr, {fpsr}",
+             "msr fpcr, {fpcr}",
+             addr_q = in(reg) addr_q,
+             fpsr = in(reg) fpu.fpsr,
+             fpcr = in(reg) fpu.fpcr,
+        );
+    }
+}
+
+pub fn restore_state(rec: &Rec<'_>) {
+    let rec_simd = &rec.context.simd;
+    let mut ns_simd = NS_SIMD[get_cpu_id()].lock();
+
+    // Disable simd traps during the context mgmt.
+    CPTR_EL2.write(CPTR_EL2::TAM::SET);
+    if rec_simd.cfg.sve_en {
+        ns_simd.sve.zcr_el2 = ZCR_EL2.get();
+        ZCR_EL2.set(rec_simd.sve.zcr_el2);
+    } else {
+        unsafe {
+            save_fpu(&mut ns_simd.fpu);
+            // Don't restore rec's simd context here.
+            // Restore fpu only if accessed instead.
+        }
+    }
+    ns_simd.cptr_el2 = CPTR_EL2.get();
+    CPTR_EL2.set(rec_simd.cptr_el2);
+}
+
+pub fn save_state(rec: &mut Rec<'_>) {
+    let rec_simd = &mut rec.context.simd;
+    let ns_simd = NS_SIMD[get_cpu_id()].lock();
+
+    // Disable simd traps during the context mgmt.
+    CPTR_EL2.write(CPTR_EL2::TAM::SET);
+    if rec_simd.cfg.sve_en {
+        rec_simd.sve.zcr_el2 = ZCR_EL2.get();
+        rec_simd.sve.zcr_el12 = ZCR_EL1.get();
+        ZCR_EL2.set(ns_simd.sve.zcr_el2);
+    } else {
+        unsafe {
+            if rec_simd.is_used {
+                save_fpu(&mut rec_simd.fpu);
+                rec_simd.is_saved = true;
+            }
+            restore_fpu(&ns_simd.fpu);
+        }
+    }
+    // To maintain immutability of rec.context during its restoration,
+    // update the context here in advance.
+    rec_simd.is_used = false;
+    rec_simd.cptr_el2 =
+        (CPTR_EL2::TAM::SET + CPTR_EL2::TSM::SET + CPTR_EL2::TFP::SET + CPTR_EL2::TZ::SET).value;
+    CPTR_EL2.set(ns_simd.cptr_el2);
+}
+
+pub fn validate(en: bool, sve_vl: u64) -> bool {
+    if en && !SIMD_CONFIG.sve_en {
+        return false;
+    }
+    if sve_vl > SIMD_CONFIG.sve_vq {
+        return false;
+    }
+    true
+}


### PR DESCRIPTION
1. exception: move non-volatile to volatile
    - Move restore_nonvolatile_registers_from_rec_and_run  to restore_volatile_registers_from_rec_and_run.
    - Make the func name short: from xxx_from_rec_and_run to xxx_from_rec.

2. rmi_features: use defined_bits() for feature register
    - rmm: fpu contenxt management for realms
    
3. rmm: fpu contenxt management for realms
   - save the fpu context on rec's exit if fpu is used during its runtime.
   - resotre the fpu context on rec's first access to fpu since its recent REC_ENTER.
