### PR TITLE
script: Add scripts to run AOSP on QEMU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ examples/cross-platform-e2ee/third-party-arm/
 unsafe-call-trace.log
 unsafe-items-list.log
 /venv
+
+android_on_qemu

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -73,3 +73,8 @@ FVP_BIN = os.path.join(FVP_DIR, "./FVP_Base_RevC-2xAEMvA")
 PLUGIN_PATH = os.path.join(THIRD_PARTY, "fvp/Base_RevC_AEMvA_pkg/plugins/Linux64_GCC-9.3/")
 TRACE_LIB = os.path.join(PLUGIN_PATH, "TarmacTrace.so")
 TOGGLE_LIB = os.path.join(PLUGIN_PATH, "ToggleMTIPlugin.so")
+
+AOSP_DIR = os.path.join(ROOT, "android_on_qemu/aosp-15.0.0_r8")
+AOSP_KERNEL_OUT = os.path.join(ROOT, "android_on_qemu/android15-6.6/out/virtual_device_aarch64/dist/")
+AOSP_KERNEL_INITRAMFS_PATH = os.path.join(AOSP_KERNEL_OUT, "initramfs.img")
+AOSP_KERNEL_IMAGE_PATH = os.path.join(AOSP_KERNEL_OUT, "Image")

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -74,7 +74,7 @@ PLUGIN_PATH = os.path.join(THIRD_PARTY, "fvp/Base_RevC_AEMvA_pkg/plugins/Linux64
 TRACE_LIB = os.path.join(PLUGIN_PATH, "TarmacTrace.so")
 TOGGLE_LIB = os.path.join(PLUGIN_PATH, "ToggleMTIPlugin.so")
 
-AOSP_DIR = os.path.join(ROOT, "android_on_qemu/aosp-15.0.0_r8")
-AOSP_KERNEL_OUT = os.path.join(ROOT, "android_on_qemu/android15-6.6/out/virtual_device_aarch64/dist/")
+AOSP_DIR = os.path.join(THIRD_PARTY, "android_on_qemu/aosp-15.0.0_r8")
+AOSP_KERNEL_OUT = os.path.join(THIRD_PARTY, "android_on_qemu/android15-6.6/out/virtual_device_aarch64/dist/")
 AOSP_KERNEL_INITRAMFS_PATH = os.path.join(AOSP_KERNEL_OUT, "initramfs.img")
 AOSP_KERNEL_IMAGE_PATH = os.path.join(AOSP_KERNEL_OUT, "Image")

--- a/scripts/init_android_on_qemu.sh
+++ b/scripts/init_android_on_qemu.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+PARENT_DIR="android_on_qemu"
+
+AOSP_VER="aosp-15.0.0_r8"
+AOSP_DIR="$PARENT_DIR/$AOSP_VER"
+AOSP_URL="https://android.googlesource.com/platform/manifest"
+AOSP_BRANCH="android-15.0.0_r8"
+
+ANDROID_KERNEL_VER="android15-6.6"
+ANDROID_KERNEL_DIR="$PARENT_DIR/$ANDROID_KERNEL_VER"
+ANDROID_KERNEL_URL="https://github.com/islet-project/3rd-android-kernel.git"
+ANDROID_KERNEL_BRANCH="common-android15-6.6/cca-host/rmm-v1.0-eac5"
+
+CUR_SCRIPT_DIR=$(dirname "$(realpath "$0")")
+ISLET_DIR=$(dirname "$CUR_SCRIPT_DIR")
+
+INITRAMFS_PATH="$ISLET_DIR/$ANDROID_KERNEL_DIR/out/virtual_device_aarch64/dist/initramfs.img"
+KERNEL_PATH="$ISLET_DIR/$ANDROID_KERNEL_DIR/out/virtual_device_aarch64/dist/Image"
+
+function install_required_packages()
+{
+	if [ -z "$(which repo)" ]; then
+		sudo apt-get install repo
+	fi
+}
+
+function build_aosp()
+{
+	cd "$ISLET_DIR" || exit
+
+	# Create aosp directory and download AOSP sources
+	if [ -d "$AOSP_DIR" ]; then
+		echo "$AOSP_DIR already exists."
+
+		echo "Changing directory to $AOSP_DIR..."
+		cd $AOSP_DIR || exit 1 # if cd failed, exit with error code
+	else
+		echo "Creating directory $AOSP_DIR..."
+		mkdir -p $AOSP_DIR
+
+		echo "Changing directory to $AOSP_DIR..."
+		cd $AOSP_DIR || exit 2 # if cd failed, exit with error code
+
+		echo "Downloading AOSP sources..."
+		repo init --partial-clone -b $AOSP_BRANCH -u $AOSP_URL
+
+		if ! repo sync -c -j8; then
+			echo "ERROR: Download AOSP failed"
+			exit 3
+		fi
+	fi
+
+	if [ -f "out/host/linux-x86/bin/launch_cvd" ]; then
+		echo "launch_cvd is exists. Skip building AOSP"
+		return
+	fi
+
+	echo "Setting up build environment..."
+	source build/envsetup.sh
+
+	echo "Choosing a target..."
+	lunch aosp_cf_arm64_only_phone-trunk_staging-userdebug
+
+	echo "Building AOSP..."
+	if ! m; then
+		echo "ERROR: AOSP Build failed"
+		exit 4
+	fi
+
+	echo "Go back to $ISLET_DIR..."
+	cd "$ISLET_DIR" || exit 5 # if cd failed, exit with error code
+}
+
+function build_android_kernel()
+{
+	cd "$ISLET_DIR" || exit
+
+	if [ ! -d "$ANDROID_KERNEL_DIR" ]; then
+		echo "Creating directory $ANDROID_KERNEL_DIR..."
+		mkdir -p "$ANDROID_KERNEL_DIR"
+	fi
+
+	echo "Changing directory to $ANDROID_KERNEL_DIR..."
+	cd $ANDROID_KERNEL_DIR || exit 1
+
+	if [ ! -d "common" ]; then
+		echo "Downloading Android Kernel sources..."
+		repo init --partial-clone -u https://android.googlesource.com/kernel/manifest -b common-$ANDROID_KERNEL_VER
+		if ! repo sync; then
+			echo "ERROR: Download Android Kernel failed"
+			exit 2
+		fi
+		echo "Replace common with cca patched kernel sources..."
+		mv common backup_common
+		git clone $ANDROID_KERNEL_URL -b $ANDROID_KERNEL_BRANCH --depth 1 --single-branch common
+	fi
+
+	if [ -f "$INITRAMFS_PATH" ] && [ -f "$KERNEL_PATH" ]; then
+		echo "Build is alread done. Skip building Android Kernel"
+		return
+	fi
+
+	# Build
+	echo "Building Android Kernel..."
+	if ! tools/bazel run //common-modules/virtual-device:virtual_device_aarch64_dist_internal; then
+		echo "ERROR: Android Kernel Build failed"
+		exit 4
+	fi
+
+	echo "Check built images..."
+	realpath $INITRAMFS_PATH
+	realpath $KERNEL_PATH
+
+	echo "Go back to $ISLET_DIR..."
+	cd $ISLET_DIR || exit 5
+}
+
+install_required_packages
+
+build_aosp
+
+build_android_kernel

--- a/scripts/init_android_on_qemu.sh
+++ b/scripts/init_android_on_qemu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PARENT_DIR="android_on_qemu"
+PARENT_DIR="third-party/android_on_qemu"
 
 AOSP_VER="aosp-15.0.0_r8"
 AOSP_DIR="$PARENT_DIR/$AOSP_VER"

--- a/scripts/qemu-cca.py
+++ b/scripts/qemu-cca.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import subprocess
+import argparse
+import subprocess
+
+from config import ROOT, AOSP_DIR, AOSP_KERNEL_INITRAMFS_PATH, AOSP_KERNEL_IMAGE_PATH
+
+def run_qemu(islet_dir, aosp_dir, initramfs_path, kernel_path):
+    subprocess.run(["./scripts/run_qemu.sh", islet_dir, aosp_dir, initramfs_path, kernel_path])
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="QEMU CCA script")
+    parser.add_argument("-aosp", action="store_true", help="Run AOSP with CCA supported host kernel on QEMU")
+    args = parser.parse_args()
+
+    if args.aosp:
+        print("Run AOSP with CCA supported host kernel on QEMU")
+        run_qemu(ROOT, AOSP_DIR, AOSP_KERNEL_INITRAMFS_PATH, AOSP_KERNEL_IMAGE_PATH)
+    else:
+        print("There is no option to run. Exiting...")

--- a/scripts/run_qemu.sh
+++ b/scripts/run_qemu.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+ISLET_DIR=$1
+AOSP_DIR=$2
+INITRAMFS_PATH=$3
+KERNEL_PATH=$4
+
+function run_qemu()
+{
+	cd "$ISLET_DIR" || exit
+	# Go to the aosp source directory which you were built before
+	echo "Changing directory to $AOSP_DIR to run qemu..."
+	cd $AOSP_DIR || exit 1
+
+	# Setup environment & select the target again
+	echo "Setting up build environment..."
+	. build/envsetup.sh
+	lunch aosp_cf_arm64_only_phone-trunk_staging-userdebug
+
+	# Run cuttlefish with cca support linux -> after start kernel, there is no logs..
+	echo "Running Cuttlefish based by QEMU..."
+	launch_cvd -vm_manager qemu_cli -enable_host_bluetooth false -report_anonymous_usage_stats=n \
+		-initramfs_path $INITRAMFS_PATH \
+		-kernel_path $KERNEL_PATH
+}
+
+run_qemu


### PR DESCRIPTION
Use the following command to build & launch android on qemu: 
./script/init_android_on_qemu.sh
./scripts/qemu-cca.py -aosp

A number of patches for CCA support are applied to the host kernel. At the moment, it supports rmm-v1.0-eac5. But it'll be updated to the latest. 
It's the below branch in [islet-project/3rd-android-kernel:](https://github.com/islet-project/3rd-android-kernel/tree/common-android15-6.6/cca-host/rmm-v1.0-eac5)
common-android15-6.6/cca-host/rmm-v1.0-eac5

If the qemu is launched, you can see information about it like this: 
"The following lines contain useful debugging information:
  Serial console is disabled; use -console=true to enable it.
  Logcat output: /home/eom/cuttlefish/instances/cvd-1/logs/logcat
  Kernel log: /home/eom/cuttlefish/instances/cvd-1/kernel.log
  Launcher log: /home/eom/cuttlefish/instances/cvd-1/logs/launcher.log
  Instance configuration: /home/eom/cuttlefish/instances/cvd-1/cuttlefish_config.json
  Launcher Build ID: eng.eom"

After the virtual device booted, you can see the following: 
VIRTUAL_DEVICE_BOOT_COMPLETED
Virtual device booted successfully

Then, check your device using adb:
$ adb devices
List of devices attached
0.0.0.0:6520	device

$ adb shell
vsoc_arm64_only:/ $ uname -a
Linux localhost 6.6.57-android15-8-maybe-dirty-4k #1 SMP PREEMPT Thu Jan  1 00:00:00 UTC 1970 aarch64 Toybox