### PR TITLE
fix: resolve pip install toml error with virtual python env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ examples/cross-platform-e2ee/third-party-arm/
 
 unsafe-call-trace.log
 unsafe-items-list.log
+/venv

--- a/scripts/deps/pkgs.sh
+++ b/scripts/deps/pkgs.sh
@@ -21,4 +21,7 @@ sudo apt-get install -y -qq --no-install-recommends --fix-missing \
 	inotify-tools \
 	pylint
 
+python3 -m venv venv
+source venv/bin/activate
 pip3 install toml
+deactivate


### PR DESCRIPTION
Fixed the issue where running `./scripts/init.sh` fails on Ubuntu 24 due to the `externally-managed-environment` error, which arises from Ubuntu 24.04 systems preventing conflicts between system and user-managed Python packages.
Implemented a solution by creating a temporary Python virtual environment for the toml installation.
Updated .gitignore to exclude the venv folder to avoid tracking the virtual environment files.
- Raised the issue for review, as using a virtual environment for a single dependency may need further discussion.
- Open to suggestions for alternative solutions
Here is screenshot of error log
![Screenshot 2024-12-31 163556](https://github.com/user-attachments/assets/a2c7fc00-4858-4199-8f31-827d001062af)
