### PR TITLE
ci: Bump artifact actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Test ACS
         run: ./scripts/tests/acs.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: acs
           path: out/uart*.log
@@ -79,7 +79,7 @@ jobs:
 #      - name: Run tf-a-tests on normal-world
 #        run: ./scripts/tests/tf-a-tests.sh
 #
-#      - uses: actions/upload-artifact@v3
+#      - uses: actions/upload-artifact@v4
 #        with:
 #          name: tf-a-tests
 #          path: out/uart*.log
@@ -100,7 +100,7 @@ jobs:
       - name: Run realm-linux booting
         run: ./scripts/tests/realm-boot.sh
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: realm-boot
           path: out/uart*.log
@@ -230,7 +230,7 @@ jobs:
     - name: Run MIRI test
       run: ./scripts/tests/miri.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: tools
         path: |
@@ -257,7 +257,7 @@ jobs:
     - name: Measure code coverage
       run: ./scripts/code-coverage.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: code-coverage
         path: code-coverage


### PR DESCRIPTION
This PR fixes the [ci error](https://github.com/islet-project/islet/actions/runs/13190291462) related with actions version.

ref) https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/