### PR TITLE
rmm: Add more RMI fuzzing harnesses

### DIFF
--- a/rmm/fuzz/Cargo.toml
+++ b/rmm/fuzz/Cargo.toml
@@ -24,3 +24,101 @@ path = "fuzz_targets/rmi_features_fuzz.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "rmi_granule_delegate_fuzz"
+path = "fuzz_targets/rmi_granule_delegate_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_granule_undelegate_fuzz"
+path = "fuzz_targets/rmi_granule_undelegate_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_realm_create_fuzz"
+path = "fuzz_targets/rmi_realm_create_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_rec_create_fuzz"
+path = "fuzz_targets/rmi_rec_create_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_rtt_create_fuzz"
+path = "fuzz_targets/rmi_rtt_create_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_rtt_read_entry_fuzz"
+path = "fuzz_targets/rmi_rtt_read_entry_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_data_create_fuzz"
+path = "fuzz_targets/rmi_data_create_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_data_create_unknown_fuzz"
+path = "fuzz_targets/rmi_data_create_unknown_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_rtt_map_unprotected_fuzz"
+path = "fuzz_targets/rmi_rtt_map_unprotected_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_rtt_init_ripas_fuzz"
+path = "fuzz_targets/rmi_rtt_init_ripas_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_rtt_set_ripas_fuzz"
+path = "fuzz_targets/rmi_rtt_set_ripas_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_rec_enter_fuzz"
+path = "fuzz_targets/rmi_rec_enter_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_psci_complete_fuzz"
+path = "fuzz_targets/rmi_psci_complete_fuzz.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "rmi_rtt_fold_fuzz"
+path = "fuzz_targets/rmi_rtt_fold_fuzz.rs"
+test = false
+doc = false
+bench = false

--- a/rmm/fuzz/fuzz_targets/rmi_data_create_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_data_create_fuzz.rs
@@ -1,0 +1,70 @@
+#![no_main]
+
+use islet_rmm::rmi::{DATA_CREATE, DATA_DESTROY, GRANULE_DELEGATE, GRANULE_UNDELEGATE,
+                     RTT_INIT_RIPAS, RTT_READ_ENTRY, SUCCESS};
+use islet_rmm::rmi::rtt_entry_state::{RMI_UNASSIGNED, RMI_ASSIGNED};
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};
+
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct DataCreateFuzz {
+    ipa: u64,
+    flags: u64,
+}
+
+fuzz_target!(|data: DataCreateFuzz| -> Corpus {
+    let ipa = data.ipa as usize;
+    let flags = data.flags as usize;
+    let base = (ipa / L3_SIZE) * L3_SIZE;
+    let data_granule = alloc_granule(IDX_DATA1);
+    let src = alloc_granule(IDX_SRC1);
+
+    let top = match (base as usize).checked_add(L3_SIZE) {
+        Some(x) => x,
+        None => {
+            return Corpus::Reject;
+        }
+    };
+
+    let rd = realm_create();
+
+    /* Reject IPAs which cannot be mapped */
+    let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+    if (ret[0] != SUCCESS) {
+        realm_destroy(rd);
+        return Corpus::Reject;
+    }
+
+    mock::host::map(rd, ipa);
+
+    let ret = rmi::<RTT_INIT_RIPAS>(&[rd, base, top]);
+    if ret[0] != SUCCESS {
+        mock::host::unmap(rd, ipa, false);
+        realm_destroy(rd);
+        return Corpus::Reject;
+    }
+
+    let _ret = rmi::<GRANULE_DELEGATE>(&[data_granule]);
+
+    let ret = rmi::<DATA_CREATE>(&[rd, data_granule, ipa, src, flags]);
+
+    if ret[0] == SUCCESS {
+        let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+        assert_eq!(ret[2], RMI_ASSIGNED);
+
+        let ret = rmi::<DATA_DESTROY>(&[rd, ipa]);
+        assert_eq!(ret[0], SUCCESS);
+
+        let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+        assert_eq!(ret[2], RMI_UNASSIGNED);
+    }
+
+    let _ret = rmi::<GRANULE_UNDELEGATE>(&[data_granule]);
+
+    mock::host::unmap(rd, ipa, false);
+    realm_destroy(rd);
+
+    Corpus::Keep
+});

--- a/rmm/fuzz/fuzz_targets/rmi_data_create_unknown_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_data_create_unknown_fuzz.rs
@@ -1,0 +1,50 @@
+#![no_main]
+
+use islet_rmm::rmi::{DATA_CREATE_UNKNOWN, DATA_DESTROY, GRANULE_DELEGATE,
+                     GRANULE_UNDELEGATE, RTT_READ_ENTRY, SUCCESS};
+use islet_rmm::rmi::rtt_entry_state::{RMI_UNASSIGNED, RMI_ASSIGNED};
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct DataCreateFuzz {
+    ipa: u64,
+}
+
+fuzz_target!(|data: DataCreateFuzz| -> Corpus {
+    let rd = realm_create();
+    let ipa = data.ipa as usize;
+    let data_granule = alloc_granule(IDX_DATA1);
+
+    /* Reject IPAs which cannot be mapped */
+    let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+    if (ret[0] != SUCCESS) {
+        realm_destroy(rd);
+        return Corpus::Reject;
+    }
+
+    mock::host::map(rd, ipa);
+
+    let _ret = rmi::<GRANULE_DELEGATE>(&[data_granule]);
+
+    let ret = rmi::<DATA_CREATE_UNKNOWN>(&[rd, data_granule, ipa]);
+
+    if ret[0] == SUCCESS {
+        let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+        assert_eq!(ret[2], RMI_ASSIGNED);
+
+        let ret = rmi::<DATA_DESTROY>(&[rd, ipa]);
+        assert_eq!(ret[0], SUCCESS);
+
+        let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+        assert_eq!(ret[2], RMI_UNASSIGNED);
+    }
+
+    let _ret = rmi::<GRANULE_UNDELEGATE>(&[data_granule]);
+
+    mock::host::unmap(rd, ipa, false);
+    realm_destroy(rd);
+
+    Corpus::Keep
+});

--- a/rmm/fuzz/fuzz_targets/rmi_granule_delegate_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_granule_delegate_fuzz.rs
@@ -1,0 +1,26 @@
+#![no_main]
+
+use islet_rmm::rmi::{GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
+use islet_rmm::granule::GRANULE_STATUS_TABLE_SIZE;
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+enum GranuleAddress {
+    GranuleRegion(u16),
+    RandomAddress(u64)
+}
+
+fuzz_target!(|data: GranuleAddress| {
+    let addr: usize = match data {
+        GranuleAddress::GranuleRegion(idx) => alloc_granule((idx as usize) % GRANULE_STATUS_TABLE_SIZE),
+        GranuleAddress::RandomAddress(addr) => addr as usize
+    };
+
+    let ret = rmi::<GRANULE_DELEGATE>(&[addr]);
+
+    if ret[0] == SUCCESS {
+        let _ret = rmi::<GRANULE_UNDELEGATE>(&[addr]);
+    }
+});

--- a/rmm/fuzz/fuzz_targets/rmi_granule_undelegate_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_granule_undelegate_fuzz.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use islet_rmm::rmi::{GRANULE_UNDELEGATE, SUCCESS};
+use islet_rmm::granule::GRANULE_STATUS_TABLE_SIZE;
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+enum GranuleAddress {
+    GranuleRegion(u16),
+    RandomAddress(u64)
+}
+
+fuzz_target!(|data: GranuleAddress| {
+    let addr: usize = match data {
+        GranuleAddress::GranuleRegion(idx) => alloc_granule((idx as usize) % GRANULE_STATUS_TABLE_SIZE),
+        GranuleAddress::RandomAddress(addr) => addr as usize
+    };
+
+    let _ret = rmi::<GRANULE_UNDELEGATE>(&[addr]);
+});

--- a/rmm/fuzz/fuzz_targets/rmi_psci_complete_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_psci_complete_fuzz.rs
@@ -1,0 +1,51 @@
+#![no_main]
+
+use islet_rmm::rmi::{REC_ENTER, PSCI_COMPLETE, SUCCESS};
+use islet_rmm::rec::Rec;
+use islet_rmm::rec::context::set_reg;
+use islet_rmm::rsi::{PSCI_CPU_ON, PSCI_AFFINITY_INFO};
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+enum PSCICommandFuzz {
+    PSCI_CPU_ON,
+    PSCI_AFFINITY_INFO,
+}
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct PSCICompleteFuzz {
+    status: usize,
+    psci_command: PSCICommandFuzz,
+    target_runnable: bool,
+}
+
+fuzz_target!(|data: PSCICompleteFuzz| {
+    let rd = mock::host::realm_setup();
+    let status = data.status;
+    let psci_command = data.psci_command;
+    let target_runnable = data.target_runnable as u64;
+
+    let (rec1, run1) = (alloc_granule(IDX_REC1), alloc_granule(IDX_REC1_RUN));
+
+    let _ret = rmi::<REC_ENTER>(&[rec1, run1]);
+
+    let rec2 = alloc_granule(IDX_REC2);
+
+    unsafe {
+        let rec = &mut *(rec1 as *mut Rec<'_>);
+        let target_rec = &mut *(rec2 as *mut Rec<'_>);
+
+        match psci_command {
+            PSCICommandFuzz::PSCI_CPU_ON => { set_reg(rec, 0, PSCI_CPU_ON).unwrap() },
+            PSCICommandFuzz::PSCI_AFFINITY_INFO => { set_reg(rec, 0, PSCI_AFFINITY_INFO).unwrap() },
+        }
+
+        target_rec.set_runnable(target_runnable);
+    }
+
+    let _ret = rmi::<PSCI_COMPLETE>(&[rec1, rec2, status]);
+
+    mock::host::realm_teardown(rd);
+});

--- a/rmm/fuzz/fuzz_targets/rmi_realm_create_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_realm_create_fuzz.rs
@@ -1,0 +1,64 @@
+#![no_main]
+
+use islet_rmm::rmi::{REALM_CREATE, REALM_DESTROY, REALM_ACTIVATE, GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
+use islet_rmm::granule::GRANULE_STATUS_TABLE_SIZE;
+use islet_rmm::rmi::realm::params::Params as RealmParams;
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RealmParamsFuzz {
+    flags: u64,
+    s2sz: u8,
+    sve_vl: u8,
+    num_bps: u8,
+    num_wps: u8,
+    pmu_num_ctrs: u8,
+    hash_algo: u8,
+    rpv: [u8; 64],
+    vmid: u16,
+    rtt_level_start: i64,
+    rtt_num_start: u32
+}
+
+fuzz_target!(|data: RealmParamsFuzz| {
+    let (rd, rtt, params_ptr) = (
+        alloc_granule(IDX_RD),
+        alloc_granule(IDX_RTT_LEVEL0),
+        alloc_granule(IDX_REALM_PARAMS),
+    );
+
+    let _ret = rmi::<GRANULE_DELEGATE>(&[rd]);
+    let _ret = rmi::<GRANULE_DELEGATE>(&[rtt]);
+
+    unsafe {
+        let params = &mut *(params_ptr as *mut RealmParams);
+
+        params.flags = data.flags;
+        params.s2sz = data.s2sz;
+        params.sve_vl = data.sve_vl;
+        params.num_bps = data.num_bps;
+        params.num_wps = data.num_wps;
+        params.pmu_num_ctrs = data.pmu_num_ctrs;
+        params.hash_algo = data.hash_algo;
+        params.rpv = data.rpv;
+        params.vmid = data.vmid;
+        params.rtt_base = rtt as u64;
+        params.rtt_level_start = data.rtt_level_start;
+        params.rtt_num_start = data.rtt_num_start;
+    }
+
+    let ret = rmi::<REALM_CREATE>(&[rd, params_ptr]);
+
+    if ret[0] == SUCCESS {
+        let _ret = rmi::<REALM_ACTIVATE>(&[rd]);
+        assert_eq!(ret[0], SUCCESS);
+
+        let ret = rmi::<REALM_DESTROY>(&[rd]);
+        assert_eq!(ret[0], SUCCESS);
+    }
+
+    let _ret = rmi::<GRANULE_UNDELEGATE>(&[rd]);
+    let _ret = rmi::<GRANULE_UNDELEGATE>(&[rtt]);
+});

--- a/rmm/fuzz/fuzz_targets/rmi_rec_create_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rec_create_fuzz.rs
@@ -1,0 +1,63 @@
+#![no_main]
+
+use islet_rmm::rmi::{REC_CREATE, REC_DESTROY, REC_AUX_COUNT, GRANULE_DELEGATE,
+                     GRANULE_UNDELEGATE, SUCCESS};
+use islet_rmm::rmi::rec::params::NR_GPRS;
+use islet_rmm::rmi::rec::params::Params as RecParams;
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RecParamsFuzz {
+    flags: u64,
+    mpidr: u64,
+    pc: u64,
+    gprs: [u64; NR_GPRS],
+}
+
+fuzz_target!(|data: RecParamsFuzz| {
+    let rd = realm_create();
+
+    let ret = rmi::<REC_AUX_COUNT>(&[rd]);
+    let rec_aux_count = ret[1];
+
+    let (rec, params_ptr) = (
+        alloc_granule(IDX_REC1),
+        alloc_granule(IDX_REC1_PARAMS),
+    );
+
+    let _ret = rmi::<GRANULE_DELEGATE>(&[rec]);
+
+    unsafe {
+        let params = &mut *(params_ptr as *mut RecParams);
+
+        params.flags = data.flags;
+        params.mpidr = data.mpidr;
+        params.pc = data.pc;
+        params.gprs = data.gprs;
+        params.num_aux = rec_aux_count as u64;
+
+        for idx in 0..rec_aux_count {
+            let mocking_addr = alloc_granule(IDX_REC1_AUX + idx);
+            let ret = rmi::<GRANULE_DELEGATE>(&[mocking_addr]);
+            params.aux[idx] = mocking_addr as u64;
+        }
+    }
+
+    let ret = rmi::<REC_CREATE>(&[rd, rec, params_ptr]);
+
+    if ret[0] == SUCCESS {
+        let ret = rmi::<REC_DESTROY>(&[rec]);
+        assert_eq!(ret[0], SUCCESS);
+    }
+
+    let _ret = rmi::<GRANULE_UNDELEGATE>(&[rec]);
+
+    for idx in 0..rec_aux_count {
+        let mocking_addr = alloc_granule(IDX_REC1_AUX + idx);
+        let _ret = rmi::<GRANULE_UNDELEGATE>(&[rec]);
+    }
+
+    realm_destroy(rd);
+});

--- a/rmm/fuzz/fuzz_targets/rmi_rec_enter_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rec_enter_fuzz.rs
@@ -1,0 +1,37 @@
+#![no_main]
+
+use islet_rmm::rmi::{REC_ENTER, SUCCESS};
+use islet_rmm::test_utils::{mock, *};
+use islet_rmm::rmi::rec::run::{Run, NR_GPRS, NR_GIC_LRS};
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RunEntryFuzz {
+    flags: u64,
+    gprs: [u64; NR_GPRS],
+    gicv3_hcr: u64,
+    gicv3_lrs: [u64; NR_GIC_LRS],
+}
+
+fuzz_target!(|data: RunEntryFuzz| {
+    let rd = mock::host::realm_setup();
+
+    let (rec1, run1) = (alloc_granule(IDX_REC1), alloc_granule(IDX_REC1_RUN));
+
+    unsafe {
+        let run = &mut *(run1 as *mut Run);
+
+        run.set_entry_flags(data.flags);
+        run.set_entry_gic_hcr(data.gicv3_hcr);
+        run.set_entry_gic_lrs(&data.gicv3_lrs, NR_GIC_LRS);
+
+        for idx in 0..NR_GPRS {
+            run.set_entry_gpr(idx, data.gprs[idx]).unwrap();
+        }
+    }
+
+    let _ret = rmi::<REC_ENTER>(&[rec1, run1]);
+
+    mock::host::realm_teardown(rd);
+});

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_create_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_create_fuzz.rs
@@ -1,0 +1,33 @@
+#![no_main]
+
+use islet_rmm::rmi::{RTT_CREATE, RTT_DESTROY, GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RTTCreateFuzz {
+    ipa: u64,
+    level: i64,
+}
+
+fuzz_target!(|data: RTTCreateFuzz| {
+    let rd = realm_create();
+    let ipa = data.ipa as usize;
+    let level = data.level as usize;
+
+    let rtt = alloc_granule(IDX_RTT_LEVEL1);
+
+    let _ret = rmi::<GRANULE_DELEGATE>(&[rtt]);
+
+    let ret = rmi::<RTT_CREATE>(&[rd, rtt, ipa, level]);
+
+    if ret[0] == SUCCESS {
+        let ret = rmi::<RTT_DESTROY>(&[rd, ipa, level]);
+        assert_eq!(ret[0], SUCCESS);
+    }
+
+    let _ret = rmi::<GRANULE_UNDELEGATE>(&[rtt]);
+
+    realm_destroy(rd);
+});

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_fold_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_fold_fuzz.rs
@@ -1,0 +1,176 @@
+#![no_main]
+
+use islet_rmm::rmi::{RTT_CREATE, RTT_READ_ENTRY, RTT_INIT_RIPAS, DATA_CREATE_UNKNOWN, DATA_DESTROY,
+                     RTT_MAP_UNPROTECTED, RTT_UNMAP_UNPROTECTED, GRANULE_DELEGATE,
+                     GRANULE_UNDELEGATE, RTT_FOLD, SUCCESS};
+use islet_rmm::granule::GRANULE_SIZE;
+use islet_rmm::test_utils::{mock, *};
+use mock::host::alloc_granule_l2_aligned as alloc_granule_l2_aligned;
+
+use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};
+
+const L2_PAGE_COUNT: usize = L2_SIZE / L3_SIZE;
+
+#[derive(Debug, Copy, Clone, arbitrary::Arbitrary)]
+enum FoldType {
+    Unassigned,
+    Assigned,
+    NonHomogenous,
+}
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RTTFoldFuzz {
+    base: u64,
+    fold_type: FoldType,
+    ram: bool,
+}
+
+/* In the cases of ASSIGNED_RAM and ASSIGNED_NS, before we can revert them
+ * to their UNASSIGNED STATES, we need to unfold them first.
+ */
+fn unfold(rd: usize, base: usize) {
+    let rtt_l3 = alloc_granule(IDX_RTT_LEVEL3);
+
+    let ret = rmi::<RTT_CREATE>(&[rd, rtt_l3, base, MAP_LEVEL]);
+    assert_eq!(ret[0], SUCCESS);
+}
+
+fn destroy_fold(rd: usize, base: usize, fold_type: FoldType, fold_success: bool) {
+    let ns: bool = (base & (1 << IPA_WIDTH - 1)) != 0;
+
+    match fold_type {
+        FoldType::Assigned => {
+            if fold_success {
+                unfold(rd, base);
+            }
+
+            for idx in 0..L2_PAGE_COUNT {
+                if ns {
+                    let ret = rmi::<RTT_UNMAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL]);
+                    assert_eq!(ret[0], SUCCESS);
+                } else {
+                    let ret = rmi::<DATA_DESTROY>(&[rd, base + idx * L3_SIZE]);
+                    assert_eq!(ret[0], SUCCESS);
+
+                    let data_granule = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA + idx);
+                    let ret = rmi::<GRANULE_UNDELEGATE>(&[data_granule]);
+                    assert_eq!(ret[0], SUCCESS);
+                }
+            }
+        },
+        FoldType::Unassigned => {},
+        FoldType::NonHomogenous => {
+            if ns {
+                let ret = rmi::<RTT_UNMAP_UNPROTECTED>(&[rd, base, MAP_LEVEL]);
+                assert_eq!(ret[0], SUCCESS);
+            } else {
+                let ret = rmi::<DATA_DESTROY>(&[rd, base]);
+                assert_eq!(ret[0], SUCCESS);
+
+                let data_granule = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA);
+                let ret = rmi::<GRANULE_UNDELEGATE>(&[data_granule]);
+                assert_eq!(ret[0], SUCCESS);
+            }
+        }
+    }
+}
+
+fn setup_fold(rd: usize, base: usize, fold_type: FoldType, ram: bool) {
+    let top = base + L2_SIZE;
+    let ns = (base & (1 << IPA_WIDTH - 1)) != 0;
+
+    if ram && !ns {
+        let ret = rmi::<RTT_INIT_RIPAS>(&[rd, base, top]);
+        assert_eq!(ret[0], SUCCESS);
+    }
+
+    match fold_type {
+        FoldType::Assigned => {
+            for idx in 0..L2_PAGE_COUNT {
+                if ns {
+                    let ns_desc = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA + idx);
+
+                    let ret = rmi::<RTT_MAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL, ns_desc]);
+                    assert_eq!(ret[0], SUCCESS);
+                } else {
+                    let data_granule = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA + idx);
+                    let ret = rmi::<GRANULE_DELEGATE>(&[data_granule]);
+                    assert_eq!(ret[0], SUCCESS);
+
+                    let ret = rmi::<DATA_CREATE_UNKNOWN>(&[rd, data_granule, base + idx * L3_SIZE]);
+                    assert_eq!(ret[0], SUCCESS);
+                }
+            }
+        },
+        FoldType::Unassigned => {
+            if ns {
+                for idx in 0..L2_PAGE_COUNT {
+                    let ns_desc = alloc_granule(IDX_NS_DESC);
+
+                    let ret = rmi::<RTT_MAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL, ns_desc]);
+                    assert_eq!(ret[0], SUCCESS);
+
+                    let ret = rmi::<RTT_UNMAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL]);
+                    assert_eq!(ret[0], SUCCESS);
+                }
+            }
+        },
+        FoldType::NonHomogenous => {
+            if ns {
+                let ns_desc = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA);
+
+                let ret = rmi::<RTT_MAP_UNPROTECTED>(&[rd, base, MAP_LEVEL, ns_desc]);
+                assert_eq!(ret[0], SUCCESS);
+            } else {
+                let data_granule = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA);
+                let ret = rmi::<GRANULE_DELEGATE>(&[data_granule]);
+                assert_eq!(ret[0], SUCCESS);
+
+                let ret = rmi::<DATA_CREATE_UNKNOWN>(&[rd, data_granule, base]);
+                assert_eq!(ret[0], SUCCESS);
+            }
+        },
+    }
+}
+
+fuzz_target!(|data: RTTFoldFuzz| -> Corpus {
+    let base = (data.base as usize / L2_SIZE) * L2_SIZE;
+    let top = match (data.base as usize).checked_add(L2_SIZE) {
+        Some(x) => x,
+        None => {
+            return Corpus::Reject;
+        }
+    };
+    let fold_type = data.fold_type;
+    let ram = data.ram;
+
+    let rd = realm_create();
+
+    /* Reject IPAs which cannot be mapped */
+    let ret = rmi::<RTT_READ_ENTRY>(&[rd, base, MAP_LEVEL]);
+    if ret[0] != SUCCESS {
+        realm_destroy(rd);
+        return Corpus::Reject;
+    }
+
+    mock::host::map(rd, base);
+
+    setup_fold(rd, base, fold_type, ram);
+
+    let ret = rmi::<RTT_FOLD>(&[rd, base, MAP_LEVEL]);
+
+    if ret[0] == SUCCESS {
+        destroy_fold(rd, base, fold_type, true);
+
+        match fold_type {
+            FoldType::Unassigned => mock::host::unmap(rd, base, true),
+            _ => mock::host::unmap(rd, base, false)
+        }
+    } else {
+        destroy_fold(rd, base, fold_type, false);
+        mock::host::unmap(rd, base, false);
+    }
+
+    realm_destroy(rd);
+    Corpus::Keep
+});

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_init_ripas_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_init_ripas_fuzz.rs
@@ -1,0 +1,34 @@
+#![no_main]
+
+use islet_rmm::rmi::{RTT_INIT_RIPAS, RTT_READ_ENTRY, SUCCESS};
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RTTInitRipasFuzz {
+    base: u64,
+    top: u64,
+}
+
+fuzz_target!(|data: RTTInitRipasFuzz| -> Corpus {
+    let rd = realm_create();
+    let base = data.base as usize;
+    let top = data.top as usize;
+
+    /* Reject IPAs which cannot be mapped */
+    let ret = rmi::<RTT_READ_ENTRY>(&[rd, base, MAP_LEVEL]);
+    if ret[0] != SUCCESS {
+        realm_destroy(rd);
+        return Corpus::Reject;
+    }
+
+    mock::host::map(rd, base);
+
+    let _ret = rmi::<RTT_INIT_RIPAS>(&[rd, base, top]);
+
+    mock::host::unmap(rd, base, false);
+
+    realm_destroy(rd);
+    Corpus::Keep
+});

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_map_unprotected_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_map_unprotected_fuzz.rs
@@ -1,0 +1,58 @@
+#![no_main]
+
+use islet_rmm::rmi::{RTT_MAP_UNPROTECTED, RTT_UNMAP_UNPROTECTED, RTT_READ_ENTRY, SUCCESS};
+use islet_rmm::rmi::rtt_entry_state::{RMI_ASSIGNED, RMI_UNASSIGNED};
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RTTUnprotected {
+    ipa: u64,
+    ATTR_NORMAL_WB_WA_RA: bool,
+    ATTR_STAGE2_AP_RW: bool,
+    ATTR_INNER_SHARED: bool,
+}
+
+fuzz_target!(|data: RTTUnprotected| -> Corpus {
+    let rd = realm_create();
+    let ipa = data.ipa as usize;
+    let mut ns = alloc_granule(IDX_NS_DESC);
+
+    /* Reject IPAs which cannot be mapped */
+    let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+    if ret[0] != SUCCESS {
+        realm_destroy(rd);
+        return Corpus::Reject;
+    }
+
+    mock::host::map(rd, ipa);
+
+    if data.ATTR_NORMAL_WB_WA_RA {
+        ns = ns | ATTR_NORMAL_WB_WA_RA;
+    }
+    if data.ATTR_STAGE2_AP_RW {
+        ns = ns | ATTR_STAGE2_AP_RW;
+    }
+    if data.ATTR_INNER_SHARED {
+        ns = ns | ATTR_INNER_SHARED;
+    }
+
+    let ret = rmi::<RTT_MAP_UNPROTECTED>(&[rd, ipa, MAP_LEVEL, ns]);
+
+    if ret[0] == SUCCESS {
+        let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+        assert_eq!(ret[2], RMI_ASSIGNED);
+
+        let ret = rmi::<RTT_UNMAP_UNPROTECTED>(&[rd, ipa, MAP_LEVEL]);
+        assert_eq!(ret[0], SUCCESS);
+
+        let ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, MAP_LEVEL]);
+        assert_eq!(ret[2], RMI_UNASSIGNED);
+    }
+
+    mock::host::unmap(rd, ipa, false);
+
+    realm_destroy(rd);
+    Corpus::Keep
+});

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_read_entry_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_read_entry_fuzz.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use islet_rmm::rmi::{RTT_READ_ENTRY, SUCCESS};
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RTTEntryReadFuzz {
+    ipa: u64,
+    level: i64,
+}
+
+fuzz_target!(|data: RTTEntryReadFuzz| {
+    let rd = realm_create();
+    let ipa = data.ipa as usize;
+    let level = data.level as usize;
+
+    let _ret = rmi::<RTT_READ_ENTRY>(&[rd, ipa, level]);
+
+    realm_destroy(rd);
+});

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_set_ripas_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_set_ripas_fuzz.rs
@@ -1,0 +1,56 @@
+#![no_main]
+
+use islet_rmm::rmi::{RTT_SET_RIPAS, REC_ENTER, RTT_READ_ENTRY, SUCCESS};
+use islet_rmm::rec::Rec;
+use islet_rmm::test_utils::{mock, *};
+
+use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+enum RIPASValue {
+    EMPTY = 0,
+    RAM = 1,
+}
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct RTTSetRIPASFuzz {
+    base: u64,
+    top: u64,
+
+    ripas_state: RIPASValue,
+    ripas_flags: u64,
+}
+
+fuzz_target!(|data: RTTSetRIPASFuzz| -> Corpus {
+    let rd = mock::host::realm_setup();
+    let base = data.base as usize;
+    let top = data.top as usize;
+    let ripas_state = data.ripas_state as u8;
+    let ripas_flags = data.ripas_flags as u64;
+
+    /* Reject IPAs which cannot be mapped */
+    let ret = rmi::<RTT_READ_ENTRY>(&[rd, base, MAP_LEVEL]);
+    if (ret[0] != SUCCESS) {
+        mock::host::realm_teardown(rd);
+        return Corpus::Reject;
+    }
+
+    let (rec1, run1) = (alloc_granule(IDX_REC1), alloc_granule(IDX_REC1_RUN));
+
+    let _ret = rmi::<REC_ENTER>(&[rec1, run1]);
+
+    unsafe {
+        let rec = &mut *(rec1 as *mut Rec<'_>);
+
+        rec.set_ripas(data.base, data.top, ripas_state, ripas_flags);
+    }
+
+    mock::host::map(rd, base);
+
+    let _ret = rmi::<RTT_SET_RIPAS>(&[rd, rec1, base, top]);
+
+    mock::host::unmap(rd, base, false);
+
+    mock::host::realm_teardown(rd);
+    Corpus::Keep
+});

--- a/rmm/src/granule/array/mod.rs
+++ b/rmm/src/granule/array/mod.rs
@@ -124,8 +124,10 @@ lazy_static! {
 pub const GRANULE_STATUS_TABLE_SIZE: usize = 0xfc000; // == RMM_MAX_GRANULES
 #[cfg(kani)]
 pub const GRANULE_STATUS_TABLE_SIZE: usize = 6;
-#[cfg(any(miri, test, fuzzing))]
+#[cfg(any(miri, test))]
 pub const GRANULE_STATUS_TABLE_SIZE: usize = 55;
+#[cfg(fuzzing)]
+pub const GRANULE_STATUS_TABLE_SIZE: usize = 2048;
 
 pub struct GranuleStatusTable {
     pub entries: [Entry; GRANULE_STATUS_TABLE_SIZE],

--- a/rmm/src/rmi/realm/mod.rs
+++ b/rmm/src/rmi/realm/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) mod params;
-pub(crate) use self::params::Params;
+pub mod params;
+pub use self::params::Params;
 use super::error::Error;
 use crate::event::RmiHandle;
 use crate::granule::GRANULE_SIZE;

--- a/rmm/src/rmi/rec/params.rs
+++ b/rmm/src/rmi/rec/params.rs
@@ -9,7 +9,7 @@ use crate::{get_granule, get_granule_if};
 use autopadding::*;
 
 pub const NR_AUX: usize = 16;
-const NR_GPRS: usize = 8;
+pub const NR_GPRS: usize = 8;
 
 pad_struct_and_impl_default!(
 pub struct Params {

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -71,6 +71,27 @@ impl Run {
         self.entry.gicv3_hcr
     }
 
+    pub fn set_entry_flags(&mut self, flags: u64) {
+        self.entry.flags = flags;
+    }
+
+    pub fn set_entry_gpr(&mut self, idx: usize, val: u64) -> Result<(), Error> {
+        if idx >= NR_GPRS {
+            error!("out of index: {}", idx);
+            return Err(Error::RmiErrorInput);
+        }
+        self.entry.gprs[idx] = val;
+        Ok(())
+    }
+
+    pub fn set_entry_gic_hcr(&mut self, val: u64) {
+        self.entry.gicv3_hcr = val;
+    }
+
+    pub fn set_entry_gic_lrs(&mut self, src: &[u64], len: usize) {
+        self.entry.gicv3_lrs.copy_from_slice(&src[..len])
+    }
+
     pub fn exit_gic_lrs_mut(&mut self) -> &mut [u64; 16] {
         &mut self.exit.gicv3_lrs
     }
@@ -208,7 +229,7 @@ pub const REC_ENTRY_FLAG_TRAP_WFE: u64 = 1 << 3;
 #[allow(dead_code)]
 pub const REC_ENTRY_FLAG_RIPAS_RESPONSE: u64 = 1 << 4;
 pub const NR_GPRS: usize = 31;
-const NR_GIC_LRS: usize = 16;
+pub const NR_GIC_LRS: usize = 16;
 
 impl Run {
     pub fn verify_compliance(&self) -> Result<(), Error> {


### PR DESCRIPTION
(LFX Task 2)

This PR adds the following harnesses:

1. rmi_granule_delegate_fuzz: Fuzzes GRANULE_DELEGATE and GRANULE_UNDELEGATE
2. rmi_granule_undelegate_fuzz: Fuzzes invalid GRANULE_UNDELEGATE calls.
3. rmi_realm_create_fuzz: Fuzzes REALM_CREATE, REALM_ACTIVATE, and REALM_DESTROY (RealmParams)
4. rmi_rec_create_fuzz: Fuzzes REC_CREATE and REC_DESTROY (RecParams)
5. rmi_rtt_create_fuzz: Fuzzes RTT_CREATE and RTT_DESTROY
6. rmi_rtt_read_entry_fuzz: Fuzzes RTT_READ_ENTRY
7. rmi_data_create_fuzz: Fuzzes DATA_CREATE and DATA_DESTROY
8. rmi_data_create_unknown_fuzz: Fuzzes DATA_CREATE_UNKNOWN and DATA_DESTROY
9. rmi_rtt_map_unprotected_fuzz: Fuzzes RTT_MAP_UNPROTECTED and RTT_UNMAP_UNPROTECTED
10. rmi_rtt_init_ripas_fuzz: Fuzzes RTT_INIT_RIPAS
11. rmi_rtt_set_ripas_fuzz: Fuzzes RTT_SET_RIPAS 
12. rmi_rec_enter_fuzz: Fuzzes REC_ENTER (Run entry paramaters)
13. rmi_psci_complete_fuzz: Fuzzes PSCI_COMPLETE
14. rmi_rtt_fold_fuzz: Fuzzes RTT_FOLD

I am still working on improving coverage wherever possible and code cleanups, so I am opting to keep it a draft for some time.
