### PR TITLE
realm/mm: Correct setting of RIPAS=EMPTY on ASSIGNED_EMPTY RTTEs

### DIFF
--- a/rmm/src/realm/mm/rtt.rs
+++ b/rmm/src/realm/mm/rtt.rs
@@ -384,7 +384,7 @@ pub fn set_ripas(rd: &Rd, base: usize, top: usize, ripas: u8, flags: u64) -> Res
         if ripas as u64 == invalid_ripas::EMPTY {
             new_s2tte |= bits_in_reg(S2TTE::INVALID_RIPAS, invalid_ripas::EMPTY);
 
-            if s2tte.is_unassigned_empty() {
+            if s2tte.is_unassigned_ram() {
                 new_s2tte |= bits_in_reg(S2TTE::INVALID_HIPAS, invalid_hipas::UNASSIGNED);
             } else if s2tte.is_unassigned_destroyed() {
                 if flags & CHANGE_DESTROYED != 0 {
@@ -404,6 +404,9 @@ pub fn set_ripas(rd: &Rd, base: usize, top: usize, ripas: u8, flags: u64) -> Res
                 } else {
                     break;
                 }
+            } else {
+                addr += map_size;
+                continue; // do nothing
             }
         } else if ripas as u64 == invalid_ripas::RAM {
             new_s2tte |= bits_in_reg(S2TTE::INVALID_RIPAS, invalid_ripas::RAM);


### PR DESCRIPTION
Currently, if RTT_SET_RIPAS were to be run on ASSIGNED_EMPTY RTTEs with the requested RIPAS being EMPTY, the HIPAS would unexpectedly change to UNASSIGNED. The expected behaviour is that the entry states should remain unchanged.

To fix this, the PR does the following:
1. Change the first case under the EMPTY request to handle UNASSIGNED_RAM instead of UNASSIGNED_EMPTY.
2. Add a fallback case which will handle both UNASSIGNED_EMPTY and ASSIGNED_EMPTY i.e the entries will be left unchanged.

This will hence mirror the code where the requested RIPAS is RAM instead.