### PR TITLE
Update RmmFeatures

### DIFF
--- a/rmm/src/realm/config.rs
+++ b/rmm/src/realm/config.rs
@@ -21,9 +21,14 @@ impl RealmConfig {
     // in parsing the following kernel cmdline argument:
     // `console=ttyS0 root=/dev/vda rw  console=pl011,mmio,0x1c0a0000 console=ttyAMA0 printk.devkmsg=on`.
     // So, we get back to use the same kernel argument with TF-RMM's one (uart0 & uart3).
-    pub fn init(config_addr: usize, ipa_width: usize, hash_algo: u8, rpv: &[u8]) -> Result<(), Error> {
+    pub fn init(
+        config_addr: usize,
+        ipa_width: usize,
+        hash_algo: u8,
+        rpv: &[u8],
+    ) -> Result<(), Error> {
         Ok(assume_safe::<RealmConfig>(config_addr)
-           .map(|mut realm_config| realm_config.init_inner(ipa_width, hash_algo, rpv))?)
+            .map(|mut realm_config| realm_config.init_inner(ipa_width, hash_algo, rpv))?)
     }
 
     fn init_inner(&mut self, ipa_width: usize, hash_algo: u8, rpv: &[u8]) {

--- a/rmm/src/realm/rd.rs
+++ b/rmm/src/realm/rd.rs
@@ -32,6 +32,7 @@ pub struct Rd {
     s2_starting_level: isize,
     hash_algo: u8,
     rpv: [u8; RPV_SIZE],
+    num_recs: usize,
     pub measurements: [Measurement; MEASUREMENTS_SLOT_NR],
     pub vcpu_index: usize,
     metadata: Option<usize>,
@@ -66,10 +67,15 @@ impl Rd {
         if sve_en {
             self.simd_cfg.sve_vq = sve_vl;
         }
+        self.num_recs = 0;
     }
 
     pub fn id(&self) -> usize {
         self.vmid as usize
+    }
+
+    pub fn num_recs(&self) -> usize {
+        self.num_recs
     }
 
     pub fn s2_table(&self) -> Arc<Mutex<Box<dyn IPATranslation>>> {
@@ -108,8 +114,13 @@ impl Rd {
         self.s2_starting_level
     }
 
-    pub fn inc_rec_index(&mut self) {
+    pub fn inc_recs(&mut self) {
+        self.num_recs += 1;
         self.rec_index += 1;
+    }
+
+    pub fn dec_recs(&mut self) {
+        self.num_recs -= 1;
     }
 
     pub fn ipa_size(&self) -> usize {

--- a/rmm/src/rec/gic.rs
+++ b/rmm/src/rec/gic.rs
@@ -70,6 +70,10 @@ lazy_static! {
     };
 }
 
+pub fn nr_lrs() -> usize {
+    GIC_FEATURES.nr_lrs
+}
+
 pub fn init_gic(rec: &mut Rec<'_>) {
     let gic_state = &mut rec.context.gic_state;
     gic_state.ich_hcr_el2 = (ICH_HCR_EL2::En.mask << ICH_HCR_EL2::En.shift)

--- a/rmm/src/rec/mod.rs
+++ b/rmm/src/rec/mod.rs
@@ -14,6 +14,8 @@ use aarch64_cpu::registers::*;
 use core::cell::OnceCell;
 use vmsa::guard::Content;
 
+const MAX_RECS_ORDER_VALUE: u64 = 4;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum RmmRecAttestState {
     AttestInProgress,
@@ -366,4 +368,8 @@ pub fn run() -> Result<[usize; 4], Error> {
 
     exit();
     Ok(ret)
+}
+
+pub fn max_recs_order() -> usize {
+    MAX_RECS_ORDER_VALUE as usize
 }

--- a/rmm/src/rec/simd.rs
+++ b/rmm/src/rec/simd.rs
@@ -287,3 +287,11 @@ pub fn validate(en: bool, sve_vl: u64) -> bool {
     }
     true
 }
+
+pub fn sve_en() -> bool {
+    SIMD_CONFIG.sve_en
+}
+
+pub fn max_sve_vl() -> u64 {
+    SIMD_CONFIG.sve_vq
+}

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -153,13 +153,13 @@ impl Params {
 
         // TODO: We don't support pmu, lpa2
         let flags = RmiRealmFlags::new(self.flags);
-        if flags.get_masked_value(RmiRealmFlags::Lpa2) != 0 {
+        if flags.get_masked_value(RmiRealmFlags::Lpa2) != features::LPA2_VALUE {
             return Err(Error::RmiErrorInput);
         }
         if !simd::validate(self.sve_en(), self.sve_vl as u64) {
             return Err(Error::RmiErrorInput);
         }
-        if flags.get_masked_value(RmiRealmFlags::Pmu) != 0 {
+        if flags.get_masked_value(RmiRealmFlags::Pmu) != features::PMU_EN_VALUE {
             return Err(Error::RmiErrorInput);
         }
 

--- a/rmm/src/rsi/ripas.rs
+++ b/rmm/src/rsi/ripas.rs
@@ -1,6 +1,5 @@
 use crate::granule::is_granule_aligned;
 use crate::granule::GranuleState;
-use crate::realm::mm::rtt::RTT_PAGE_LEVEL;
 use crate::realm::mm::stage2_tte::invalid_ripas;
 use crate::realm::rd::Rd;
 use crate::rec::context::{get_reg, set_reg};
@@ -8,7 +7,6 @@ use crate::rec::Rec;
 use crate::rmi;
 use crate::rmi::error::Error;
 use crate::rmi::rec::run::{Run, REC_ENTRY_FLAG_RIPAS_RESPONSE};
-use crate::rmi::rtt::validate_ipa;
 use crate::rsi;
 use crate::Monitor;
 use crate::{get_granule, get_granule_if};

--- a/scripts/fvp/launch-realm-debian.sh
+++ b/scripts/fvp/launch-realm-debian.sh
@@ -7,6 +7,7 @@ echo "copy done"
 
 ./configure-net.sh &
 ./lkvm run \
+	--restricted_mem \
 	--realm \
 	--measurement-algo="sha256" \
 	--disable-sve \

--- a/scripts/fvp/launch-realm.sh
+++ b/scripts/fvp/launch-realm.sh
@@ -12,6 +12,7 @@ fi
 
 ./lkvm run \
 	--debug \
+	--restricted_mem \
 	--realm \
 	--measurement-algo="sha256" \
 	--disable-sve \


### PR DESCRIPTION
1.  Update RmmFeatures
    - add num_recs_order
    - relocate the position of existing fields in output for RMI_FEATURES

    Affected RMIs
    - RMI_FEATURES
    - RMI_REALM_CREATE
    - RMI_REC_CREATE/DESTROY

2. apply checks from clippy and cargo fmt
3. Update lkvm argument for the linux private memory usage