### PR TITLE
ci: Apply cargo fmt to all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,8 +156,7 @@ jobs:
 
     - name: Check rust coding-style
       run: |
-        cd rmm && cargo fmt -- --check && cd -
-        cd plat/fvp && cargo fmt -- --check
+        cargo fmt -- --check
 
     - name: Check clippy lints
       run: ./scripts/clippy.sh

--- a/rmm/fuzz/fuzz_targets/rmi_data_create_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_data_create_fuzz.rs
@@ -1,12 +1,13 @@
 #![no_main]
 
-use islet_rmm::rmi::{DATA_CREATE, DATA_DESTROY, GRANULE_DELEGATE, GRANULE_UNDELEGATE,
-                     RTT_INIT_RIPAS, RTT_READ_ENTRY, SUCCESS};
-use islet_rmm::rmi::rtt_entry_state::{RMI_UNASSIGNED, RMI_ASSIGNED};
+use islet_rmm::rmi::rtt_entry_state::{RMI_ASSIGNED, RMI_UNASSIGNED};
+use islet_rmm::rmi::{
+    DATA_CREATE, DATA_DESTROY, GRANULE_DELEGATE, GRANULE_UNDELEGATE, RTT_INIT_RIPAS,
+    RTT_READ_ENTRY, SUCCESS,
+};
 use islet_rmm::test_utils::{mock, *};
 
 use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};
-
 
 #[derive(Debug, arbitrary::Arbitrary)]
 struct DataCreateFuzz {

--- a/rmm/fuzz/fuzz_targets/rmi_data_create_unknown_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_data_create_unknown_fuzz.rs
@@ -1,8 +1,10 @@
 #![no_main]
 
-use islet_rmm::rmi::{DATA_CREATE_UNKNOWN, DATA_DESTROY, GRANULE_DELEGATE,
-                     GRANULE_UNDELEGATE, RTT_READ_ENTRY, SUCCESS};
-use islet_rmm::rmi::rtt_entry_state::{RMI_UNASSIGNED, RMI_ASSIGNED};
+use islet_rmm::rmi::rtt_entry_state::{RMI_ASSIGNED, RMI_UNASSIGNED};
+use islet_rmm::rmi::{
+    DATA_CREATE_UNKNOWN, DATA_DESTROY, GRANULE_DELEGATE, GRANULE_UNDELEGATE, RTT_READ_ENTRY,
+    SUCCESS,
+};
 use islet_rmm::test_utils::{mock, *};
 
 use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};

--- a/rmm/fuzz/fuzz_targets/rmi_features_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_features_fuzz.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use islet_rmm::rmi::{FEATURES};
+use islet_rmm::rmi::FEATURES;
 use islet_rmm::test_utils::*;
 
 use libfuzzer_sys::fuzz_target;

--- a/rmm/fuzz/fuzz_targets/rmi_granule_delegate_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_granule_delegate_fuzz.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
-use islet_rmm::rmi::{GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
 use islet_rmm::granule::GRANULE_STATUS_TABLE_SIZE;
+use islet_rmm::rmi::{GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
 use islet_rmm::test_utils::{mock, *};
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
@@ -9,13 +9,15 @@ use libfuzzer_sys::{arbitrary, fuzz_target};
 #[derive(Debug, arbitrary::Arbitrary)]
 enum GranuleAddress {
     GranuleRegion(u16),
-    RandomAddress(u64)
+    RandomAddress(u64),
 }
 
 fuzz_target!(|data: GranuleAddress| {
     let addr: usize = match data {
-        GranuleAddress::GranuleRegion(idx) => alloc_granule((idx as usize) % GRANULE_STATUS_TABLE_SIZE),
-        GranuleAddress::RandomAddress(addr) => addr as usize
+        GranuleAddress::GranuleRegion(idx) => {
+            alloc_granule((idx as usize) % GRANULE_STATUS_TABLE_SIZE)
+        }
+        GranuleAddress::RandomAddress(addr) => addr as usize,
     };
 
     let ret = rmi::<GRANULE_DELEGATE>(&[addr]);

--- a/rmm/fuzz/fuzz_targets/rmi_granule_undelegate_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_granule_undelegate_fuzz.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
-use islet_rmm::rmi::{GRANULE_UNDELEGATE, SUCCESS};
 use islet_rmm::granule::GRANULE_STATUS_TABLE_SIZE;
+use islet_rmm::rmi::{GRANULE_UNDELEGATE, SUCCESS};
 use islet_rmm::test_utils::{mock, *};
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
@@ -9,13 +9,15 @@ use libfuzzer_sys::{arbitrary, fuzz_target};
 #[derive(Debug, arbitrary::Arbitrary)]
 enum GranuleAddress {
     GranuleRegion(u16),
-    RandomAddress(u64)
+    RandomAddress(u64),
 }
 
 fuzz_target!(|data: GranuleAddress| {
     let addr: usize = match data {
-        GranuleAddress::GranuleRegion(idx) => alloc_granule((idx as usize) % GRANULE_STATUS_TABLE_SIZE),
-        GranuleAddress::RandomAddress(addr) => addr as usize
+        GranuleAddress::GranuleRegion(idx) => {
+            alloc_granule((idx as usize) % GRANULE_STATUS_TABLE_SIZE)
+        }
+        GranuleAddress::RandomAddress(addr) => addr as usize,
     };
 
     let _ret = rmi::<GRANULE_UNDELEGATE>(&[addr]);

--- a/rmm/fuzz/fuzz_targets/rmi_realm_create_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_realm_create_fuzz.rs
@@ -1,8 +1,10 @@
 #![no_main]
 
-use islet_rmm::rmi::{REALM_CREATE, REALM_DESTROY, REALM_ACTIVATE, GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
 use islet_rmm::granule::GRANULE_STATUS_TABLE_SIZE;
 use islet_rmm::rmi::realm::params::Params as RealmParams;
+use islet_rmm::rmi::{
+    GRANULE_DELEGATE, GRANULE_UNDELEGATE, REALM_ACTIVATE, REALM_CREATE, REALM_DESTROY, SUCCESS,
+};
 use islet_rmm::test_utils::{mock, *};
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
@@ -19,7 +21,7 @@ struct RealmParamsFuzz {
     rpv: [u8; 64],
     vmid: u16,
     rtt_level_start: i64,
-    rtt_num_start: u32
+    rtt_num_start: u32,
 }
 
 fuzz_target!(|data: RealmParamsFuzz| {

--- a/rmm/fuzz/fuzz_targets/rmi_rec_create_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rec_create_fuzz.rs
@@ -1,9 +1,10 @@
 #![no_main]
 
-use islet_rmm::rmi::{REC_CREATE, REC_DESTROY, REC_AUX_COUNT, GRANULE_DELEGATE,
-                     GRANULE_UNDELEGATE, SUCCESS};
-use islet_rmm::rmi::rec::params::NR_GPRS;
 use islet_rmm::rmi::rec::params::Params as RecParams;
+use islet_rmm::rmi::rec::params::NR_GPRS;
+use islet_rmm::rmi::{
+    GRANULE_DELEGATE, GRANULE_UNDELEGATE, REC_AUX_COUNT, REC_CREATE, REC_DESTROY, SUCCESS,
+};
 use islet_rmm::test_utils::{mock, *};
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
@@ -22,10 +23,7 @@ fuzz_target!(|data: RecParamsFuzz| {
     let ret = rmi::<REC_AUX_COUNT>(&[rd]);
     let rec_aux_count = ret[1];
 
-    let (rec, params_ptr) = (
-        alloc_granule(IDX_REC1),
-        alloc_granule(IDX_REC1_PARAMS),
-    );
+    let (rec, params_ptr) = (alloc_granule(IDX_REC1), alloc_granule(IDX_REC1_PARAMS));
 
     let _ret = rmi::<GRANULE_DELEGATE>(&[rec]);
 

--- a/rmm/fuzz/fuzz_targets/rmi_rec_enter_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rec_enter_fuzz.rs
@@ -1,8 +1,8 @@
 #![no_main]
 
+use islet_rmm::rmi::rec::run::{Run, NR_GIC_LRS, NR_GPRS};
 use islet_rmm::rmi::{REC_ENTER, SUCCESS};
 use islet_rmm::test_utils::{mock, *};
-use islet_rmm::rmi::rec::run::{Run, NR_GPRS, NR_GIC_LRS};
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
 

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_create_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_create_fuzz.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use islet_rmm::rmi::{RTT_CREATE, RTT_DESTROY, GRANULE_DELEGATE, GRANULE_UNDELEGATE, SUCCESS};
+use islet_rmm::rmi::{GRANULE_DELEGATE, GRANULE_UNDELEGATE, RTT_CREATE, RTT_DESTROY, SUCCESS};
 use islet_rmm::test_utils::{mock, *};
 
 use libfuzzer_sys::{arbitrary, fuzz_target};

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_fold_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_fold_fuzz.rs
@@ -1,11 +1,12 @@
 #![no_main]
 
-use islet_rmm::rmi::{RTT_CREATE, RTT_READ_ENTRY, RTT_INIT_RIPAS, DATA_CREATE_UNKNOWN, DATA_DESTROY,
-                     RTT_MAP_UNPROTECTED, RTT_UNMAP_UNPROTECTED, GRANULE_DELEGATE,
-                     GRANULE_UNDELEGATE, RTT_FOLD, SUCCESS};
 use islet_rmm::granule::GRANULE_SIZE;
+use islet_rmm::rmi::{
+    DATA_CREATE_UNKNOWN, DATA_DESTROY, GRANULE_DELEGATE, GRANULE_UNDELEGATE, RTT_CREATE, RTT_FOLD,
+    RTT_INIT_RIPAS, RTT_MAP_UNPROTECTED, RTT_READ_ENTRY, RTT_UNMAP_UNPROTECTED, SUCCESS,
+};
 use islet_rmm::test_utils::{mock, *};
-use mock::host::alloc_granule_l2_aligned as alloc_granule_l2_aligned;
+use mock::host::alloc_granule_l2_aligned;
 
 use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};
 
@@ -57,8 +58,8 @@ fn destroy_fold(rd: usize, base: usize, fold_type: FoldType, fold_success: bool)
                     assert_eq!(ret[0], SUCCESS);
                 }
             }
-        },
-        FoldType::Unassigned => {},
+        }
+        FoldType::Unassigned => {}
         FoldType::NonHomogenous => {
             if ns {
                 let ret = rmi::<RTT_UNMAP_UNPROTECTED>(&[rd, base, MAP_LEVEL]);
@@ -90,7 +91,8 @@ fn setup_fold(rd: usize, base: usize, fold_type: FoldType, ram: bool) {
                 if ns {
                     let ns_desc = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA + idx);
 
-                    let ret = rmi::<RTT_MAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL, ns_desc]);
+                    let ret =
+                        rmi::<RTT_MAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL, ns_desc]);
                     assert_eq!(ret[0], SUCCESS);
                 } else {
                     let data_granule = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA + idx);
@@ -101,20 +103,21 @@ fn setup_fold(rd: usize, base: usize, fold_type: FoldType, ram: bool) {
                     assert_eq!(ret[0], SUCCESS);
                 }
             }
-        },
+        }
         FoldType::Unassigned => {
             if ns {
                 for idx in 0..L2_PAGE_COUNT {
                     let ns_desc = alloc_granule(IDX_NS_DESC);
 
-                    let ret = rmi::<RTT_MAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL, ns_desc]);
+                    let ret =
+                        rmi::<RTT_MAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL, ns_desc]);
                     assert_eq!(ret[0], SUCCESS);
 
                     let ret = rmi::<RTT_UNMAP_UNPROTECTED>(&[rd, base + idx * L3_SIZE, MAP_LEVEL]);
                     assert_eq!(ret[0], SUCCESS);
                 }
             }
-        },
+        }
         FoldType::NonHomogenous => {
             if ns {
                 let ns_desc = alloc_granule_l2_aligned(IDX_L2_ALIGNED_DATA);
@@ -129,7 +132,7 @@ fn setup_fold(rd: usize, base: usize, fold_type: FoldType, ram: bool) {
                 let ret = rmi::<DATA_CREATE_UNKNOWN>(&[rd, data_granule, base]);
                 assert_eq!(ret[0], SUCCESS);
             }
-        },
+        }
     }
 }
 
@@ -164,7 +167,7 @@ fuzz_target!(|data: RTTFoldFuzz| -> Corpus {
 
         match fold_type {
             FoldType::Unassigned => mock::host::unmap(rd, base, true),
-            _ => mock::host::unmap(rd, base, false)
+            _ => mock::host::unmap(rd, base, false),
         }
     } else {
         destroy_fold(rd, base, fold_type, false);

--- a/rmm/fuzz/fuzz_targets/rmi_rtt_map_unprotected_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_rtt_map_unprotected_fuzz.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
-use islet_rmm::rmi::{RTT_MAP_UNPROTECTED, RTT_UNMAP_UNPROTECTED, RTT_READ_ENTRY, SUCCESS};
 use islet_rmm::rmi::rtt_entry_state::{RMI_ASSIGNED, RMI_UNASSIGNED};
+use islet_rmm::rmi::{RTT_MAP_UNPROTECTED, RTT_READ_ENTRY, RTT_UNMAP_UNPROTECTED, SUCCESS};
 use islet_rmm::test_utils::{mock, *};
 
 use libfuzzer_sys::{arbitrary, fuzz_target, Corpus};

--- a/rmm/fuzz/fuzz_targets/rmi_version_fuzz.rs
+++ b/rmm/fuzz/fuzz_targets/rmi_version_fuzz.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use islet_rmm::rmi::{VERSION};
+use islet_rmm::rmi::VERSION;
 use islet_rmm::test_utils::*;
 
 use libfuzzer_sys::fuzz_target;


### PR DESCRIPTION
With this PR, cargo fmt would be applied to all rust modules during CI checks, rather than rmm and fvp exclusively. This would prevent unformatted code in other modules (e.g., fuzz tests) from passing CI tests. To pass CI, it includes the previous @bokdeuk-jeong's commit of applying cargo fmt to fuzz tests.