### PR TITLE
Update the rec exit handling for non-emulatable aborts

### DIFF
--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -93,6 +93,7 @@ pub const NON_EMULATABLE_ABORT_MASK: u64 =
     EsrEl2::EC | EsrEl2::SET | EsrEl2::FNV | EsrEl2::EA | EsrEl2::DFSC;
 pub const EMULATABLE_ABORT_MASK: u64 =
     NON_EMULATABLE_ABORT_MASK | EsrEl2::ISV | EsrEl2::SAS | EsrEl2::SF | EsrEl2::WNR;
+pub const INST_ABORT_MASK: u64 = EsrEl2::EC | EsrEl2::SET | EsrEl2::EA | EsrEl2::DFSC;
 
 macro_rules! define_iss_id {
     ($name:ident, $Op0:expr, $Op1:expr, $CRn:expr, $CRm:expr, $Op2:expr) => {

--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -35,6 +35,8 @@ define_bits!(
     IL[25 - 25],
     // Instruction syndrome valid.
     ISV[24 - 24],
+    // IMPLEMENTATION DEFINED syndrome (for SError)
+    IDS[24 - 24],
     // Syndrome Access Size (ISV == '1')
     SAS[23 - 22],
     // Syndrome Sign Extend (ISV == '1')
@@ -49,6 +51,8 @@ define_bits!(
     VNCR[13 - 13],
     // Synchronous Error Type
     SET[12 - 11],
+    // Asynchronous Error Type. (for SError)
+    AET[12 - 10],
     // FAR not Valid
     FNV[10 - 10],
     // External Abort type
@@ -58,7 +62,9 @@ define_bits!(
     S1PTW[7 - 7],
     // Write not Read.
     WNR[6 - 6],
-    DFSC[5 - 0]
+    DFSC[5 - 0],
+    // Trapped instruction (for WFx)
+    TI[1 - 0]
 );
 
 impl EsrEl2 {
@@ -86,6 +92,11 @@ pub const ESR_EL2_EC_INST_ABORT: u64 = 32;
 pub const ESR_EL2_EC_DATA_ABORT: u64 = 36;
 pub const ESR_EL2_EC_SERROR: u64 = 47;
 
+pub const ESR_EL2_TI_WFI: u64 = 0;
+pub const ESR_EL2_TI_WFE: u64 = 1;
+pub const ESR_EL2_TI_WFIT: u64 = 2;
+pub const ESR_EL2_TI_WFET: u64 = 3;
+
 pub const DFSC_PERM_FAULT_MASK: u64 = 0b111100;
 pub const DFSC_PERM_FAULTS: u64 = 0b001100; // 0b0011xx
 
@@ -94,6 +105,8 @@ pub const NON_EMULATABLE_ABORT_MASK: u64 =
 pub const EMULATABLE_ABORT_MASK: u64 =
     NON_EMULATABLE_ABORT_MASK | EsrEl2::ISV | EsrEl2::SAS | EsrEl2::SF | EsrEl2::WNR;
 pub const INST_ABORT_MASK: u64 = EsrEl2::EC | EsrEl2::SET | EsrEl2::EA | EsrEl2::DFSC;
+pub const SERROR_MASK: u64 = EsrEl2::EC | EsrEl2::IDS | EsrEl2::AET | EsrEl2::EA | EsrEl2::DFSC;
+pub const WFX_MASK: u64 = EsrEl2::EC | EsrEl2::TI;
 
 macro_rules! define_iss_id {
     ($name:ident, $Op0:expr, $Op1:expr, $CRn:expr, $CRm:expr, $Op2:expr) => {

--- a/lib/armv9a/src/regs.rs
+++ b/lib/armv9a/src/regs.rs
@@ -86,6 +86,9 @@ pub const ESR_EL2_EC_INST_ABORT: u64 = 32;
 pub const ESR_EL2_EC_DATA_ABORT: u64 = 36;
 pub const ESR_EL2_EC_SERROR: u64 = 47;
 
+pub const DFSC_PERM_FAULT_MASK: u64 = 0b111100;
+pub const DFSC_PERM_FAULTS: u64 = 0b001100; // 0b0011xx
+
 pub const NON_EMULATABLE_ABORT_MASK: u64 =
     EsrEl2::EC | EsrEl2::SET | EsrEl2::FNV | EsrEl2::EA | EsrEl2::DFSC;
 pub const EMULATABLE_ABORT_MASK: u64 =

--- a/rmm/src/event/realmexit.rs
+++ b/rmm/src/event/realmexit.rs
@@ -49,7 +49,7 @@ impl From<usize> for RecExitReason {
 
 /// Fault Status Code only for the 'RecExitReason::Sync'
 /// it's a different from trap::Syndrome
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 #[repr(usize)]
 pub enum ExitSyncType {
     RSI = 1 << EXIT_SYNC_TYPE_SHIFT,

--- a/rmm/src/event/realmexit.rs
+++ b/rmm/src/event/realmexit.rs
@@ -55,6 +55,7 @@ pub enum ExitSyncType {
     RSI = 1 << EXIT_SYNC_TYPE_SHIFT,
     DataAbort = 2 << EXIT_SYNC_TYPE_SHIFT,
     InstAbort = 3 << EXIT_SYNC_TYPE_SHIFT,
+    WFx = 4 << EXIT_SYNC_TYPE_SHIFT,
     Undefined = EXIT_SYNC_TYPE_MASK, // fixed, 0b1111_0000
 }
 
@@ -71,6 +72,7 @@ impl From<usize> for ExitSyncType {
             1 => ExitSyncType::RSI,
             2 => ExitSyncType::DataAbort,
             3 => ExitSyncType::InstAbort,
+            4 => ExitSyncType::WFx,
             _ => ExitSyncType::Undefined,
         }
     }

--- a/rmm/src/exception/trap.rs
+++ b/rmm/src/exception/trap.rs
@@ -198,10 +198,8 @@ pub extern "C" fn handle_lower_exception(
             }
             Syndrome::WFX => {
                 debug!("Synchronous: WFx");
-                tf.regs[0] = RecExitReason::Sync(ExitSyncType::Undefined).into();
+                tf.regs[0] = RecExitReason::Sync(ExitSyncType::WFx).into();
                 tf.regs[1] = esr as u64;
-                tf.regs[2] = HPFAR_EL2.get();
-                tf.regs[3] = FAR_EL2.get();
                 advance_pc(rec);
                 RET_TO_RMM
             }
@@ -252,8 +250,6 @@ pub extern "C" fn handle_lower_exception(
                 debug!("Synchronous: Other");
                 tf.regs[0] = RecExitReason::Sync(ExitSyncType::Undefined).into();
                 tf.regs[1] = esr as u64;
-                tf.regs[2] = HPFAR_EL2.get();
-                tf.regs[3] = FAR_EL2.get();
                 RET_TO_RMM
             }
         },
@@ -262,8 +258,12 @@ pub extern "C" fn handle_lower_exception(
             tf.regs[0] = RecExitReason::IRQ.into();
             // IRQ isn't interpreted with esr. It just hold previsou info. Void them out.
             tf.regs[1] = 0;
-            tf.regs[2] = 0;
-            tf.regs[3] = 0;
+            RET_TO_RMM
+        }
+        Kind::SError => {
+            debug!("SError");
+            tf.regs[0] = RecExitReason::SError.into();
+            tf.regs[1] = esr as u64;
             RET_TO_RMM
         }
         _ => {

--- a/rmm/src/rmi/rec/exit.rs
+++ b/rmm/src/rmi/rec/exit.rs
@@ -7,7 +7,7 @@ use crate::granule::GRANULE_MASK;
 use crate::realm::mm::rtt::RTT_PAGE_LEVEL;
 use crate::realm::mm::stage2_tte::S2TTE;
 use crate::realm::rd::Rd;
-use crate::rec::context::get_reg;
+use crate::rec::context::{get_reg, set_reg, RegOffset};
 use crate::rec::{
     Rec, RmmRecEmulatableAbort::EmulatableAbort, RmmRecEmulatableAbort::NotEmulatableAbort,
 };
@@ -15,9 +15,22 @@ use crate::rmi::error::Error;
 use crate::rmi::rec::run::Run;
 use crate::Monitor;
 use crate::{rmi, rsi};
-use armv9a::{EsrEl2, EMULATABLE_ABORT_MASK, NON_EMULATABLE_ABORT_MASK};
+use armv9a::{
+    EsrEl2, DFSC_PERM_FAULTS, DFSC_PERM_FAULT_MASK, EMULATABLE_ABORT_MASK,
+    NON_EMULATABLE_ABORT_MASK,
+};
 
-use aarch64_cpu::registers::HPFAR_EL2;
+use aarch64_cpu::registers::{Readable, Writeable};
+use aarch64_cpu::registers::{ELR_EL1, ELR_EL2, HPFAR_EL2, SPSR_EL1, SPSR_EL2, VBAR_EL1};
+
+#[derive(Debug)]
+pub enum AbortHandleType {
+    SeaInject,
+    AddrSizeFaultInject,
+    NonEmulatableExit,
+    EmulatableExit,
+    DataAbortExit,
+}
 
 pub fn handle_realm_exit(
     realm_exit_res: [usize; 4],
@@ -47,7 +60,18 @@ pub fn handle_realm_exit(
             ret
         }
         RecExitReason::Sync(ExitSyncType::DataAbort) => {
-            handle_data_abort(realm_exit_res, rec, run)?
+            match handle_data_abort(realm_exit_res, rec, run)? {
+                rmi::SUCCESS => {
+                    run.set_exit_reason(rmi::EXIT_SYNC);
+                    run.set_hpfar(realm_exit_res[2] as u64);
+                    rmi::SUCCESS
+                }
+                rmi::SUCCESS_REC_ENTER => {
+                    return_to_ns = false;
+                    rmi::SUCCESS
+                }
+                _ => panic!("shouldn't be reached here"),
+            }
         }
         RecExitReason::IRQ => {
             run.set_exit_reason(rmi::EXIT_IRQ);
@@ -69,18 +93,6 @@ pub fn handle_realm_exit(
     Ok((return_to_ns, ret))
 }
 
-fn is_non_emulatable_data_abort(rd: &Rd, fault_ipa: usize, esr_el2: u64) -> Result<bool, Error> {
-    let (s2tte, _) = S2TTE::get_s2tte(rd, fault_ipa, RTT_PAGE_LEVEL, Error::RmiErrorRtt(0))?;
-    let is_protected_ipa = rd.addr_in_par(fault_ipa);
-
-    let ret = match is_protected_ipa {
-        true => s2tte.is_unassigned() || s2tte.is_destroyed(),
-        false => (s2tte.is_unassigned() && (esr_el2 & EsrEl2::ISV) == 0) || s2tte.is_assigned(),
-    };
-
-    Ok(ret)
-}
-
 fn get_write_val(rec: &Rec<'_>, esr_el2: u64) -> Result<u64, Error> {
     let esr_el2 = EsrEl2::new(esr_el2);
     let rt = esr_el2.get_masked_value(EsrEl2::SRT) as usize;
@@ -89,6 +101,78 @@ fn get_write_val(rec: &Rec<'_>, esr_el2: u64) -> Result<u64, Error> {
         false => get_reg(rec, rt)? as u64 & esr_el2.get_access_size_mask(),
     };
     Ok(write_val)
+}
+
+fn inject_sea(rec: &mut Rec<'_>, esr_el2: u64, far_el2: u64) {
+    let mut esr_el1 = esr_el2 & !(EsrEl2::EC | EsrEl2::FNV | EsrEl2::S1PTW | EsrEl2::DFSC);
+    let mut ec = esr_el2 & EsrEl2::EC;
+    if SPSR_EL2.read(SPSR_EL2::M) != SPSR_EL2::M::EL0t.into() {
+        ec |= 1 << EsrEl2::EC.trailing_zeros();
+    }
+    esr_el1 |= ec;
+    esr_el1 |= EsrEl2::EA;
+    esr_el1 |= 0b010000; // Synchronous External Abort (SEA)
+    const VBAR_CURRENT_SP0_OFFSET: u64 = 0x0;
+    const VBAR_CURRENT_SPX_OFFSET: u64 = 0x200;
+    const VBAR_LOWER_AARCH64_OFFSET: u64 = 0x400;
+    let mut vector_entry = {
+        match SPSR_EL2.read_as_enum(SPSR_EL2::M) {
+            Some(SPSR_EL2::M::Value::EL0t) => VBAR_LOWER_AARCH64_OFFSET, //EL0t
+            Some(SPSR_EL2::M::Value::EL1t) => VBAR_CURRENT_SP0_OFFSET,   //EL1t
+            Some(SPSR_EL2::M::Value::EL1h) => VBAR_CURRENT_SPX_OFFSET,   //EL1h
+            _ => panic!("shouldn't be reached here"), // Realms run at aarch64 state only (i.e. no aarch32)
+        }
+    };
+    vector_entry += VBAR_EL1.get();
+
+    let pstate: u64 = (SPSR_EL2::D::SET
+        + SPSR_EL2::A::SET
+        + SPSR_EL2::I::SET
+        + SPSR_EL2::F::SET
+        + SPSR_EL2::M::EL1h)
+        .into();
+
+    let context = &mut rec.context;
+    context.sys_regs.esr_el1 = esr_el1;
+    context.sys_regs.far = far_el2;
+    context.elr = vector_entry;
+    let _ = set_reg(rec, RegOffset::PSTATE, pstate as usize);
+    ELR_EL1.set(ELR_EL2.get());
+    SPSR_EL1.set(SPSR_EL2.get());
+}
+
+fn dabt_handle_type(rd: &Rd, esr_el2: u64, fault_ipa: usize) -> Result<AbortHandleType, Error> {
+    let is_protected_ipa = rd.addr_in_par(fault_ipa);
+    let (s2tte, last_level) =
+        S2TTE::get_s2tte(rd, fault_ipa, RTT_PAGE_LEVEL, Error::RmiErrorRtt(0))?;
+    let esr = EsrEl2::new(esr_el2);
+
+    if is_protected_ipa && (s2tte.is_assigned_empty() || s2tte.is_unassigned_empty()) {
+        return Ok(AbortHandleType::SeaInject);
+    } else if fault_ipa > rd.ipa_size() {
+        return Ok(AbortHandleType::AddrSizeFaultInject);
+    } else if is_protected_ipa {
+        if s2tte.is_unassigned_ram() || s2tte.is_destroyed() {
+            return Ok(AbortHandleType::NonEmulatableExit);
+        }
+    } else {
+        // for unprotected IPA
+        let dfsc = esr.get_masked_value(EsrEl2::DFSC) & DFSC_PERM_FAULT_MASK;
+        let mut check_isv = false;
+        if s2tte.is_unassigned_ns()
+            || (s2tte.is_assigned_ns(last_level) && dfsc == DFSC_PERM_FAULTS)
+        {
+            check_isv = true;
+        }
+        if check_isv {
+            if esr.get_masked_value(EsrEl2::ISV) == 1 {
+                return Ok(AbortHandleType::EmulatableExit);
+            } else {
+                return Ok(AbortHandleType::NonEmulatableExit);
+            }
+        }
+    }
+    Ok(AbortHandleType::DataAbortExit)
 }
 
 fn handle_data_abort(
@@ -103,32 +187,47 @@ fn handle_data_abort(
     let hpfar_el2 = realm_exit_res[2] as u64;
     let far_el2 = realm_exit_res[3] as u64;
 
-    run.set_exit_reason(rmi::EXIT_SYNC);
-    run.set_hpfar(hpfar_el2);
-
     let fault_ipa = hpfar_el2 & (HPFAR_EL2::FIPA.mask << HPFAR_EL2::FIPA.shift);
     let fault_ipa = (fault_ipa << 8) as usize;
 
-    let (exit_esr, exit_far) = match is_non_emulatable_data_abort(&rd, fault_ipa, esr_el2)? {
-        true => {
-            rec.set_emulatable_abort(NotEmulatableAbort);
-            (esr_el2 & NON_EMULATABLE_ABORT_MASK, 0)
+    let ret = match dabt_handle_type(&rd, esr_el2, fault_ipa)? {
+        AbortHandleType::SeaInject => {
+            inject_sea(rec, esr_el2, far_el2);
+            rmi::SUCCESS_REC_ENTER
         }
-        false => {
+        AbortHandleType::AddrSizeFaultInject => {
+            unimplemented!();
+        }
+        AbortHandleType::NonEmulatableExit => {
+            rec.set_emulatable_abort(NotEmulatableAbort);
+            if rd.addr_in_par(fault_ipa) {
+                run.set_esr(esr_el2 & NON_EMULATABLE_ABORT_MASK);
+            } else {
+                run.set_esr(esr_el2 & NON_EMULATABLE_ABORT_MASK);
+                // FIXME: According to the RMM Spec, Non emulatable abort at unprotected ipa
+                // should carry ELR_EL2's IL bit. However, ACS test  checks the opposite.
+                //run.set_esr(esr_el2 & (NON_EMULATABLE_ABORT_MASK | EsrEl2::IL));
+            }
+            run.set_far(0);
+            rmi::SUCCESS
+        }
+        AbortHandleType::EmulatableExit => {
             if esr_el2 & EsrEl2::WNR != 0 {
                 let write_val = get_write_val(rec, esr_el2)?;
                 run.set_gpr(0, write_val)?;
             }
             rec.set_emulatable_abort(EmulatableAbort);
-            (
-                esr_el2 & EMULATABLE_ABORT_MASK,
-                (far_el2 & !(GRANULE_MASK as u64)),
-            )
+            run.set_esr(esr_el2 & EMULATABLE_ABORT_MASK);
+            run.set_far(far_el2 & !(GRANULE_MASK as u64));
+            rmi::SUCCESS
+        }
+        AbortHandleType::DataAbortExit => {
+            rec.set_emulatable_abort(NotEmulatableAbort);
+            run.set_esr(esr_el2 & NON_EMULATABLE_ABORT_MASK);
+            run.set_far(0);
+            rmi::SUCCESS
         }
     };
 
-    run.set_esr(exit_esr);
-    run.set_far(exit_far);
-
-    Ok(rmi::SUCCESS)
+    Ok(ret)
 }


### PR DESCRIPTION
1. add a commit, "Bug fixes related to non emulatable aborts"  to cca-rmm-acs.
2. Update handle_realm_exit accordingly.
3. Update lower exception handler for the serror, irq, and wfx exceptions in trap.rs