### PR TITLE
Fix t32 script

### DIFF
--- a/debug/t32.cmm
+++ b/debug/t32.cmm
@@ -1,13 +1,14 @@
 system.reset
 
-system.cpu CORTEXA72A53
-system.config corenumber 8.
+system.cpu ARMV8-A
+;system.config corenumber 8.
 
-core.assign 1. 2. 3. 4. 5. 6. 7. 8.
+;core.assign 1. 2. 3. 4. 5. 6. 7. 8.
 
 sys.up
 
 d.load.elf ../out/aarch64-unknown-none-softfloat/release/fvp /nocode
+Data.LOAD.Elf ../third-party/nw-linux/vmlinux /NoCODE /noclear
 
 list
 register


### PR DESCRIPTION
There were some compatibility issues between the target CPU of T32 and FVP which prevented T32 from running in our default setting. The fix chooses the right CPU and uses only one core. The command for loading linux symbols has been also added.