### PR TITLE
Fix psci feature (v1.0-rel0)

### DIFF
--- a/rmm/src/rsi/psci.rs
+++ b/rmm/src/rsi/psci.rs
@@ -157,7 +157,8 @@ pub fn set_event_handler(rsi: &mut RsiHandle) {
     listen!(rsi, rsi::PSCI_FEATURES, |_arg, ret, _rmm, rec, _run| {
         let feature_id = get_reg(rec, 1)?;
         let retval = match feature_id {
-            rsi::PSCI_CPU_SUSPEND
+            rsi::SMCCC_VERSION //XXX: this should be added for realm-linux booting
+            | rsi::PSCI_CPU_SUSPEND
             | rsi::PSCI_CPU_OFF
             | rsi::PSCI_CPU_ON
             | rsi::PSCI_AFFINITY_INFO


### PR DESCRIPTION
This contains one commit about `PSCI_FEATURE` from https://github.com/islet-project/islet/pull/435. The major issue about realm-linux booting has been addressed in https://github.com/islet-project/islet/pull/445. On top of it, this will help to support realm-linux booting in 1.0-rel0.

After the internal discussion with @bokdeuk-jeong, I've realized that RTT iter function starts from index 0 not from in the middle of the given IPA, which was my main misunderstanding about that API. 