### PR TITLE
support for qemu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     "lib/uart",
     "lib/vmsa",
     "model-checking",
-    "plat/fvp",
+    "plat/",
     "realm/rsi-test",
     "rmm/",
     "rmm/fuzz/",

--- a/lib/uart/src/pl011.rs
+++ b/lib/uart/src/pl011.rs
@@ -36,7 +36,7 @@ const UARTMIS: isize = 0x040 / REG_LEN;
 #[allow(dead_code)]
 const UARTDMACR: isize = 0x048 / REG_LEN;
 
-const UARTFR_TXFF_BIT: u32 = 5;
+const UARTFR_TXFF: u32 = 1 << 5;
 
 #[allow(dead_code)]
 enum UARTCR {
@@ -87,7 +87,7 @@ impl DeviceInner {
     pub fn putc(&mut self, byte: u8) -> Result<()> {
         if self.ready {
             unsafe {
-                while self.register.offset(UARTFR).read_volatile() & UARTFR_TXFF_BIT == 0 {}
+                while self.register.offset(UARTFR).read_volatile() & UARTFR_TXFF != 0 {}
                 self.register.offset(UARTDR).write_volatile(byte as u32);
             }
             Ok(())

--- a/plat/.cargo/config.toml
+++ b/plat/.cargo/config.toml
@@ -3,7 +3,6 @@ target = "aarch64-unknown-none-softfloat"
 
 [target.aarch64-unknown-none-softfloat]
 rustflags = [
-  "-C", "link-args=-Tplat/fvp/memory.x",
   "-C", "target-feature=+ecv",
   "-C", "target-feature=+sme",
   "-C", "target-feature=+tlb-rmi"

--- a/plat/Cargo.toml
+++ b/plat/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "fvp"
+name = "islet-rmm"
 version = "0.0.1"
 authors = ["Islet Contributors"]
 edition = "2021"
+build   = "build.rs"
 
 [[bin]]
-name = "fvp"
+name = "islet-rmm"
 path = "src/main.rs"
 
 [features]
@@ -17,15 +18,17 @@ max_level_debug = ["log/max_level_debug", "islet_rmm/max_level_debug"]
 max_level_trace = ["log/max_level_trace", "islet_rmm/max_level_trace"]
 stat = ["islet_rmm/stat"]
 gst_page_table = ["islet_rmm/gst_page_table"]
+fvp = []
+qemu = []
 
 [dependencies]
 aarch64-cpu = { version = "10.0.0" }
 bitflags = "1.3"
-islet_rmm = { path = "../../rmm" }
+islet_rmm = { path = "../rmm" }
 linked_list_allocator = "0.10.4"
 log = "0.4.17"
-uart = { path = "../../lib/uart" }
-io = { path = "../../lib/io" }
+uart = { path = "../lib/uart" }
+io = { path = "../lib/io" }
 
 [build-dependencies]
 cc = "1.0"

--- a/plat/Cargo.toml
+++ b/plat/Cargo.toml
@@ -18,8 +18,8 @@ max_level_debug = ["log/max_level_debug", "islet_rmm/max_level_debug"]
 max_level_trace = ["log/max_level_trace", "islet_rmm/max_level_trace"]
 stat = ["islet_rmm/stat"]
 gst_page_table = ["islet_rmm/gst_page_table"]
-fvp = []
-qemu = []
+fvp = ["islet_rmm/fvp"]
+qemu = ["islet_rmm/qemu"]
 
 [dependencies]
 aarch64-cpu = { version = "10.0.0" }

--- a/plat/build.rs
+++ b/plat/build.rs
@@ -1,8 +1,9 @@
-use std::{env, fs, path::Path};
+use std::env;
 
 fn main() {
     let platform = env::var("PLATFORM").unwrap_or_else(|_| {
-        panic!("Please set the PLATFORM environment variable (e.g., PLATFORM=fvp)")
+        "fvp".to_string()
+        //panic!("Please set the PLATFORM environment variable (e.g., PLATFORM=fvp)")
     });
 
     let memory_file = format!("plat/{}/memory.x", platform);

--- a/plat/build.rs
+++ b/plat/build.rs
@@ -1,0 +1,16 @@
+use std::{env, fs, path::Path};
+
+fn main() {
+    let platform = env::var("PLATFORM").unwrap_or_else(|_| {
+        panic!("Please set the PLATFORM environment variable (e.g., PLATFORM=fvp)")
+    });
+
+    let memory_file = format!("plat/{}/memory.x", platform);
+    println!("cargo:rustc-link-arg=-T{}", memory_file);
+
+    println!("cargo:rustc-cfg=plat_{}", platform);
+
+    // Re-run build if platform or memory.x changes
+    println!("cargo:rerun-if-env-changed=PLATFORM");
+    println!("cargo:rerun-if-changed={}", memory_file);
+}

--- a/plat/fvp/plat.rs
+++ b/plat/fvp/plat.rs
@@ -1,0 +1,6 @@
+// TODO: get these from the manifest provided by el3 on rmm's entry
+pub const UART_BASE: usize = 0x1C0C_0000;
+//pub const UART_BAUDRATE: usize = 115200;
+//pub const UART_CLK_IN_HZ: usize = 24000000;
+// Last page of Realm PAS assigned to RMM contains manifest written by EL3
+pub const EL3_SHARED_BUF: u64 = 0xFFBFF000;

--- a/plat/qemu/memory.x
+++ b/plat/qemu/memory.x
@@ -1,7 +1,7 @@
-SIZE_4MB = 0x400000;
-SIZE_32MB = 0x2000000;
+SIZE_1MB = 0x100000;
+SIZE_40MB = 0x2800000;
 SIZE_4KB = 0x1000;
-SIZE_2GB = 0x80000000;
+SIZE_8GB = 0x200000000;
 
 ENTRY(rmm_entry);
 
@@ -9,17 +9,18 @@ ENTRY(rmm_entry);
  *
  * Partition            | Origin      | Length
  * ---------------------|-------------|-----------
- * NS PAS (Non-Secure)  | 0x80000000  | 0x7C000000 (2GB - 64MB)
- * Secure PAS           | 0xFC000000  | 0x01C00000 (28MB)
- * Realm PAS            | 0xFDC00000  | 0x02000000 (32MB)
- * Root PAS             | 0xFFC00000  | 0x00400000 (4MB)
+ * NS PAS (Non-Secure)  | 0x40000000  |    0x100000 (1MB)
+ * NS PAS (Non-Secure)  | 0x42900000  | 0x600000000 (3GB~)
+ * Secure PAS           | 0x0E100000  |    0xE00000 (14MB)
+ * Realm PAS            | 0x40100000  |   0x2800000 (40MB)
+ * Root PAS             | 0x0E001000  |     0xFF000 (1MB-1KB)
+ * Root PAS             | 0x0EDFC000  |    0x204000 (2MB+16KB)
  * ---------------------|-------------|-----------
  */
 
 MEMORY {
-    RAM (rwx)      : ORIGIN = 0x80000000, LENGTH = SIZE_2GB
-    ROOT_PAS (rwx) : ORIGIN = ORIGIN(RAM) + LENGTH(RAM) - SIZE_4MB, LENGTH = SIZE_4MB
-    REALM_PAS (rxw): ORIGIN = ORIGIN(ROOT_PAS) - SIZE_32MB, LENGTH = SIZE_32MB
+    RAM (rwx)      : ORIGIN = 0x40000000, LENGTH = SIZE_1MB
+    REALM_PAS (rxw): ORIGIN = ORIGIN(RAM) + SIZE_1MB, LENGTH = SIZE_40MB
 }
 
 SECTIONS {
@@ -73,5 +74,5 @@ SECTIONS {
     __RMM_END__ = .;
 
     /* LENGTH(REALM_PAS) - SIZE_4KB: last page is reserved for the el3 manifest */
-    ASSERT((__RMM_END__ < ORIGIN(REALM_PAS) + LENGTH(REALM_PAS)) - SIZE_4KB, "REALM_PAS size exceeded!")
+    ASSERT((__RMM_END__ < ORIGIN(REALM_PAS) + LENGTH(REALM_PAS) - SIZE_4KB), "REALM_PAS size exceeded!")
 }

--- a/plat/qemu/plat.rs
+++ b/plat/qemu/plat.rs
@@ -1,0 +1,6 @@
+// TODO: get these from the manifest provided by el3 on rmm's entry
+pub const UART_BASE: usize = 0x900_0000;
+//pub const UART_BAUDRATE: usize = 115200;
+//pub const UART_CLK_IN_HZ: usize = 1;
+// Last page of Realm PAS assigned to RMM contains manifest written by EL3
+pub const EL3_SHARED_BUF: u64 = 0x428F_F000;

--- a/plat/src/entry.rs
+++ b/plat/src/entry.rs
@@ -7,6 +7,8 @@ use io::stdout;
 use islet_rmm::config::{NUM_OF_CPU, RMM_STACK_GUARD_SIZE, RMM_STACK_SIZE};
 use islet_rmm::logger;
 
+use crate::plat;
+
 /// Configure the first page of the stack section as a stack guard page
 #[no_mangle]
 #[link_section = ".stack"]
@@ -25,6 +27,11 @@ pub unsafe extern "C" fn current_cpu_stack() -> usize {
     &RMM_STACK[cpu_id] as *const u8 as usize + RMM_STACK_SIZE
 }
 
+// TODO : save boot args
+// x0 : CPUID
+// x1 : Version for this Boot interface
+// x2 : platform core count
+// x3 : Base address for the EL3 <-> RMM shared area
 #[naked]
 #[link_section = ".head.text"]
 #[no_mangle]
@@ -57,9 +64,8 @@ unsafe fn clear_bss() {
     bss.fill(0);
 }
 
-fn init_console() {
-    const UART3_BASE: usize = 0x1c0c_0000usize;
-    let _ = stdout().attach(uart::pl011::device(UART3_BASE));
+pub fn init_console() {
+    let _ = stdout().attach(uart::pl011::device(plat::UART_BASE));
     logger::register_global_logger(LevelFilter::Trace); // Control log level
     info!("Initialized the console!");
 }

--- a/plat/src/main.rs
+++ b/plat/src/main.rs
@@ -8,6 +8,7 @@
 extern crate log;
 
 mod entry;
+mod plat;
 
 use aarch64_cpu::registers::*;
 use islet_rmm::allocator;
@@ -35,7 +36,8 @@ pub unsafe fn main() -> ! {
             rw_start: &__RW_START__ as *const u64 as u64,
             rw_end: &__RW_END__ as *const u64 as u64,
             stack_base: &__RMM_STACK_BASE__ as *const u64 as u64,
-            uart_phys: 0x1c0c_0000,
+            uart_phys: plat::UART_BASE as u64,
+            el3_shared_buf: plat::EL3_SHARED_BUF,
         }
     };
     islet_rmm::start(cpu::get_cpu_id(), layout);

--- a/plat/src/plat.rs
+++ b/plat/src/plat.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "fvp")]
+include!("../fvp/plat.rs");
+
+#[cfg(feature = "qemu")]
+include!("../qemu/plat.rs");

--- a/plat/src/plat.rs
+++ b/plat/src/plat.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "fvp")]
+#[cfg(any(feature = "fvp", not(feature = "qemu")))]
 include!("../fvp/plat.rs");
 
 #[cfg(feature = "qemu")]

--- a/rmm/Cargo.toml
+++ b/rmm/Cargo.toml
@@ -38,6 +38,8 @@ max_level_debug = ["log/max_level_debug"]
 max_level_trace = ["log/max_level_trace"]
 stat = []
 gst_page_table = []
+fvp = []
+qemu = []
 
 # The below are features relevant for model checking
 mc_rmi_features = []

--- a/rmm/src/config.rs
+++ b/rmm/src/config.rs
@@ -18,6 +18,8 @@ pub const RMM_HEAP_SIZE: usize = 16 * 1024 * 1024;
 pub const VM_STACK_SIZE: usize = 1 << 15;
 pub const STACK_ALIGN: usize = 16;
 
+pub const SMCCC_1_3_SVE_HINT: usize = 1 << 16;
+
 #[derive(Debug, Default)]
 pub struct PlatformMemoryLayout {
     pub rmm_base: u64,

--- a/rmm/src/config.rs
+++ b/rmm/src/config.rs
@@ -11,7 +11,7 @@ pub const PAGE_SIZE: usize = 1 << PAGE_BITS; // 4KiB
 pub const LARGE_PAGE_SIZE: usize = 1024 * 1024 * 2; // 2MiB
 pub const HUGE_PAGE_SIZE: usize = 1024 * 1024 * 1024; // 1GiB
 
-#[cfg(feature = "fvp")]
+#[cfg(any(feature = "fvp", not(feature = "qemu")))]
 pub const MAX_DRAM_SIZE: usize = 0xFC00_0000; // 4GB - 64MB
 #[cfg(feature = "qemu")]
 pub const MAX_DRAM_SIZE: usize = 0x2_0000_0000; // 8GB

--- a/rmm/src/config.rs
+++ b/rmm/src/config.rs
@@ -11,6 +11,11 @@ pub const PAGE_SIZE: usize = 1 << PAGE_BITS; // 4KiB
 pub const LARGE_PAGE_SIZE: usize = 1024 * 1024 * 2; // 2MiB
 pub const HUGE_PAGE_SIZE: usize = 1024 * 1024 * 1024; // 1GiB
 
+#[cfg(feature = "fvp")]
+pub const MAX_DRAM_SIZE: usize = 0xFC00_0000; // 4GB - 64MB
+#[cfg(feature = "qemu")]
+pub const MAX_DRAM_SIZE: usize = 0x2_0000_0000; // 8GB
+
 pub const RMM_STACK_GUARD_SIZE: usize = crate::granule::GRANULE_SIZE * 1;
 pub const RMM_STACK_SIZE: usize = 1024 * 1024 - RMM_STACK_GUARD_SIZE;
 pub const RMM_HEAP_SIZE: usize = 16 * 1024 * 1024;

--- a/rmm/src/cpu.rs
+++ b/rmm/src/cpu.rs
@@ -8,10 +8,20 @@ pub extern "C" fn get_cpu_id() -> usize {
     cluster * NUM_OF_CPU_PER_CLUSTER + core
 }
 
+#[cfg(feature = "fvp")]
 #[inline(always)]
 pub fn id() -> (usize, usize) {
     (
         MPIDR_EL1.read(MPIDR_EL1::Aff2) as usize,
         MPIDR_EL1.read(MPIDR_EL1::Aff1) as usize,
+    )
+}
+
+#[cfg(feature = "qemu")]
+#[inline(always)]
+pub fn id() -> (usize, usize) {
+    (
+        MPIDR_EL1.read(MPIDR_EL1::Aff1) as usize,
+        MPIDR_EL1.read(MPIDR_EL1::Aff0) as usize,
     )
 }

--- a/rmm/src/cpu.rs
+++ b/rmm/src/cpu.rs
@@ -8,7 +8,7 @@ pub extern "C" fn get_cpu_id() -> usize {
     cluster * NUM_OF_CPU_PER_CLUSTER + core
 }
 
-#[cfg(feature = "fvp")]
+#[cfg(any(feature = "fvp", not(feature = "qemu")))]
 #[inline(always)]
 pub fn id() -> (usize, usize) {
     (

--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -26,6 +26,7 @@ pub struct Context {
     pub cmd: Command,
     pub arg: Vec<usize>,
     pub ret: Vec<usize>,
+    pub sve_hint: bool,
 }
 
 impl Context {
@@ -34,6 +35,7 @@ impl Context {
             cmd,
             arg: Vec::new(),
             ret: Vec::new(),
+            sve_hint: false,
         }
     }
 

--- a/rmm/src/granule/array/mod.rs
+++ b/rmm/src/granule/array/mod.rs
@@ -110,7 +110,7 @@ lazy_static! {
 }
 
 #[cfg(not(any(kani, miri, test, fuzzing)))]
-pub const GRANULE_STATUS_TABLE_SIZE: usize = 0xfc000; // == RMM_MAX_GRANULES
+pub const GRANULE_STATUS_TABLE_SIZE: usize = config::MAX_DRAM_SIZE / GRANULE_SIZE; // == RMM_MAX_GRANULES
 #[cfg(kani)]
 pub const GRANULE_STATUS_TABLE_SIZE: usize = 6;
 #[cfg(any(miri, test))]

--- a/rmm/src/granule/page_table/mod.rs
+++ b/rmm/src/granule/page_table/mod.rs
@@ -5,6 +5,7 @@ use self::entry::{Entry, Inner};
 use self::translation::{
     GranuleStatusTable, GRANULE_STATUS_TABLE, L0_TABLE_ENTRY_SIZE_RANGE, L1_TABLE_ENTRY_SIZE_RANGE,
 };
+use crate::config;
 use crate::rmi::error::Error as RmiError;
 
 use core::ptr::addr_of_mut;
@@ -209,23 +210,13 @@ pub fn set_granule_raw(addr: usize, state: u64) -> Result<(), Error> {
     }
 }
 
-// TODO: move this FVP-specific address info
-const FVP_DRAM0_REGION: core::ops::Range<usize> = core::ops::Range {
-    start: 0x8000_0000,
-    end: 0x8000_0000 + 0x7C00_0000 - 1,
-};
-const FVP_DRAM1_REGION: core::ops::Range<usize> = core::ops::Range {
-    start: 0x8_8000_0000,
-    end: 0x8_8000_0000 + 0x8000_0000 - 1,
-};
-
 pub fn validate_addr(addr: usize) -> bool {
     if addr % GRANULE_SIZE != 0 {
         // if the address is out of range.
         warn!("address need to be aligned 0x{:X}", addr);
         return false;
     }
-    if !(FVP_DRAM0_REGION.contains(&addr) || FVP_DRAM1_REGION.contains(&addr)) {
+    if !config::is_ns_dram(addr) {
         // if the address is out of range.
         warn!("address is strange 0x{:X}", addr);
         return false;

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -72,13 +72,14 @@ use core::ptr::addr_of;
 /// - The `layout` must be a valid `PlatformMemoryLayout` appropriate for the platform.
 /// - Calling this function may alter system-level configurations and should be done with caution.
 pub unsafe fn start(cpu_id: usize, layout: PlatformMemoryLayout) {
+    let el3_shared_buf = layout.el3_shared_buf;
     setup_mmu_cfg(layout);
     setup_el2();
     #[cfg(feature = "gst_page_table")]
     setup_gst();
     // TODO: call once or with every start?
     if cpu_id == 0 {
-        setup_el3_ifc();
+        setup_el3_ifc(el3_shared_buf);
     }
 
     Monitor::new().run();

--- a/rmm/src/mm/translation.rs
+++ b/rmm/src/mm/translation.rs
@@ -1,8 +1,6 @@
 use super::page_table::entry::Entry;
 use super::page_table::{attr, L1Table};
-use crate::config::{
-    PlatformMemoryLayout, PAGE_SIZE, RMM_SHARED_BUFFER_START, RMM_STACK_GUARD_SIZE, RMM_STACK_SIZE,
-};
+use crate::config::{PlatformMemoryLayout, PAGE_SIZE, RMM_STACK_GUARD_SIZE, RMM_STACK_SIZE};
 use crate::mm::page::BasePageSize;
 use crate::mm::page_table::entry::PTDesc;
 
@@ -90,7 +88,7 @@ impl Inner<'_> {
         let ro_size = rw_start - base_address;
         let rw_size = layout.rw_end - rw_start;
         let uart_phys = layout.uart_phys;
-        let shared_start = RMM_SHARED_BUFFER_START;
+        let el3_shared_page = layout.el3_shared_buf;
         self.set_pages(
             VirtAddr::from(base_address),
             PhysAddr::from(base_address),
@@ -121,8 +119,8 @@ impl Inner<'_> {
             rw_flags | device_flags,
         );
         self.set_pages(
-            VirtAddr::from(shared_start),
-            PhysAddr::from(shared_start),
+            VirtAddr::from(el3_shared_page),
+            PhysAddr::from(el3_shared_page),
             PAGE_SIZE,
             rw_flags | rmm_flags,
         );

--- a/rmm/src/rmi/constraint.rs
+++ b/rmm/src/rmi/constraint.rs
@@ -1,3 +1,4 @@
+use crate::config::SMCCC_1_3_SVE_HINT;
 use crate::event::{Command, Context};
 use crate::rmi;
 
@@ -58,12 +59,17 @@ fn pick(cmd: Command) -> Option<Constraint> {
 }
 
 pub fn validate(cmd: Command, arg: &[usize]) -> Context {
-    if let Some(c) = pick(cmd) {
-        let mut ctx = Context::new(cmd);
+    let fid = cmd & !SMCCC_1_3_SVE_HINT;
+    if let Some(c) = pick(fid) {
+        let mut ctx = Context::new(fid);
         ctx.init_arg(&arg[..(c.arg_num - 1)]);
         ctx.resize_ret(c.ret_num);
+        if cmd & SMCCC_1_3_SVE_HINT != 0 {
+            ctx.sve_hint = true;
+        }
         ctx
     } else {
+        error!("Coudlnt find constraint for command: {:X}", cmd);
         Context::new(rmi::NOT_SUPPORTED_YET)
     }
 }

--- a/rmm/src/rmm_el3/manifest.rs
+++ b/rmm/src/rmm_el3/manifest.rs
@@ -1,0 +1,156 @@
+use autopadding::*;
+use safe_abstraction::raw_ptr::assume_safe;
+use safe_abstraction::raw_ptr::Error;
+use spinning_top::SpinlockGuard;
+
+use super::RMM_SHARED_BUFFER_LOCK;
+use crate::config;
+/*
+ * Boot Manifest structure illustration, with two dram banks and
+ * a single console.
+ *
+ * +----------------------------------------+
+ * | offset |     field      |    comment   |
+ * +--------+----------------+--------------+
+ * |   0    |    version     |  0x00000003  |
+ * +--------+----------------+--------------+
+ * |   4    |    padding     |  0x00000000  |
+ * +--------+----------------+--------------+
+ * |   8    |   plat_data    |     NULL     |
+ * +--------+----------------+--------------+
+ * |   16   |   num_banks    |              |
+ * +--------+----------------+              |
+ * |   24   |     banks      |   plat_dram  |
+ * +--------+----------------+              |
+ * |   32   |    checksum    |              |
+ * +--------+----------------+--------------+
+ * |   40   |  num_consoles  |              |
+ * +--------+----------------+              |
+ * |   48   |    consoles    | plat_console |
+ * +--------+----------------+              |
+ * |   56   |    checksum    |              |
+ * +--------+----------------+--------------+
+ * |   64   |     base 0     |              |
+ * +--------+----------------+    bank[0]   |
+ * |   72   |     size 0     |              |
+ * +--------+----------------+--------------+
+ * +--------+----------------+    bank[N]   |
+ * +--------+----------------+--------------+
+ * |   X    |     base       |              |
+ * +--------+----------------+              |
+ * |   X+8  |   map_pages    |              |
+ * +--------+----------------+              |
+ * |   X+16 |     name       |              |
+ * +--------+----------------+  consoles[0] |
+ * |   X+24 |   clk_in_hz    |              |
+ * +--------+----------------+              |
+ * |   X+32 |   baud_rate    |              |
+ * +--------+----------------+              |
+ * |   X+40 |     flags      |              |
+ * +--------+----------------+--------------+
+ * +--------+----------------+  consoles[M] |
+ * +--------+----------------+--------------+
+ */
+
+// Console info structure
+/*
+#[repr(C)]
+pub struct ConsoleInfo {
+    pub base: u64,       // Console base address
+    pub map_pages: u64,  // Num of pages to be mapped in RMM for the console MMIO
+    pub name: [u8; 8],           // Name of console
+    pub clk_in_hz: u64,  // UART clock (in Hz) for the console
+    pub baud_rate: u64,  // Baud rate
+    pub flags: u64,      // Additional flags RES0
+}
+*/
+
+// NS DRAM bank structure
+#[repr(C)]
+pub struct DramBank {
+    pub base: u64, // Base address
+    pub size: u64, // Size of bank
+}
+
+// Boot manifest core structure as per v0.3
+pad_struct_and_impl_default!(
+pub struct RmmManifest {
+    0x0  pub version: u32,           // Manifest version
+    0x8  pub plat_data_ptr: u64,     // Manifest platform data
+    0x10 pub num_banks: u64,         // plat_dram.banks
+    0x18 pub banks_ptr: u64,         // plat_dram.banks_ptr
+    0x20 pub banks_checksum: u64,     // plat_dram.bank_checksum
+    0x28 pub num_consoles: u64,      // plat_console.num_consoles
+    0x30 pub consoles_ptr: u64,      // plat_console.consoles
+    0x38 pub console_checksum: u64,  // plat_console.checksum
+    0x40 => @END,
+}
+);
+
+const EL3_IFC_VERSION: u32 = 0x00000003;
+
+pub fn load() -> core::result::Result<(), Error> {
+    debug!("Configuring RMM with EL3 manifest");
+    let guard: SpinlockGuard<'_, _> = RMM_SHARED_BUFFER_LOCK.lock();
+    let manifest = assume_safe::<RmmManifest>(*guard)?;
+    let struct_size = core::mem::size_of::<DramBank>();
+    let mut dram_vec = config::NS_DRAM_REGIONS.lock();
+    debug!("version: {:?}", manifest.version);
+    debug!("num_banks: {:x}", manifest.num_banks);
+    if manifest.version != EL3_IFC_VERSION {
+        panic!(
+            "manifest version {:X} not supported. requires {:X}",
+            manifest.version, EL3_IFC_VERSION
+        );
+    }
+    let mut bank_ptr = manifest.banks_ptr as usize;
+    let mut max_base = 0;
+    for i in 0..manifest.num_banks {
+        let bank = assume_safe::<DramBank>(bank_ptr)?;
+        debug!(
+            "NS_DRAM[{:?}]: {:X}-{:X} (size:{:X})",
+            i,
+            bank.base,
+            bank.base + bank.size,
+            bank.size
+        );
+        dram_vec.push(core::ops::Range {
+            start: bank.base as usize,
+            end: (bank.base + bank.size) as usize,
+        });
+        bank_ptr += struct_size;
+        if bank.base < max_base {
+            panic!("Islet only accepts an ordered bank list");
+        }
+        max_base = bank.base;
+    }
+    Ok(())
+}
+
+impl safe_abstraction::raw_ptr::RawPtr for RmmManifest {}
+
+impl safe_abstraction::raw_ptr::SafetyChecked for RmmManifest {}
+
+impl safe_abstraction::raw_ptr::SafetyAssured for RmmManifest {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn verify_ownership(&self) -> bool {
+        true
+    }
+}
+
+impl safe_abstraction::raw_ptr::RawPtr for DramBank {}
+
+impl safe_abstraction::raw_ptr::SafetyChecked for DramBank {}
+
+impl safe_abstraction::raw_ptr::SafetyAssured for DramBank {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn verify_ownership(&self) -> bool {
+        true
+    }
+}

--- a/rmm/src/rmm_el3/mod.rs
+++ b/rmm/src/rmm_el3/mod.rs
@@ -18,7 +18,6 @@ const ATTEST_KEY_CURVE_ECC_SECP384R1: usize = 0;
 const VHUK_LENGTH: usize = 32;
 
 static RMM_SHARED_BUFFER_LOCK: Spinlock<usize> = Spinlock::new(0);
-//0x428F_F000;
 static REALM_ATTEST_KEY: Spinlock<Vec<u8>> = Spinlock::new(Vec::new());
 static PLAT_TOKEN: Spinlock<Vec<u8>> = Spinlock::new(Vec::new());
 static VHUK_A: Spinlock<[u8; VHUK_LENGTH]> = Spinlock::new([0xAAu8; VHUK_LENGTH]);

--- a/rmm/src/rsi/constraint.rs
+++ b/rmm/src/rsi/constraint.rs
@@ -1,3 +1,4 @@
+use crate::config::SMCCC_1_3_SVE_HINT;
 use crate::event::{Command, Context};
 use crate::rmi::constraint::Constraint; // TODO: we might need rsi's own constraint struct in the future
 use crate::rsi;
@@ -39,8 +40,12 @@ fn pick(cmd: Command) -> Option<Constraint> {
 }
 
 pub fn validate(cmd: Command) -> Context {
-    let mut ctx = Context::new(cmd);
-    if let Some(c) = pick(cmd) {
+    let fid = cmd & !SMCCC_1_3_SVE_HINT;
+    let mut ctx = Context::new(fid);
+    if cmd & SMCCC_1_3_SVE_HINT != 0 {
+        ctx.sve_hint = true;
+    }
+    if let Some(c) = pick(fid) {
         ctx.resize_ret(c.ret_num);
     } else {
         // rmm.handle_rsi takes care of unregistered command.

--- a/scripts/fvp-cca
+++ b/scripts/fvp-cca
@@ -239,6 +239,7 @@ def get_rmm_features(args):
             features += ["--features", "stat"]
         if args.normal_world == "acs":
             features += ["--features", "gst_page_table"]
+        features += ["--features", "fvp"]
 
     if features:
         print("[!] Setting", args.rmm, "features:", features)
@@ -253,9 +254,11 @@ def prepare_rmm(rmm, features):
         args = ["cargo", "build", "--release"]
         args += features
 
-        run(args, cwd=RMM)
+        new_env = os.environ.copy()
+        new_env["PLATFORM"] = "fvp"
+        run(args, cwd=RMM, new_env=new_env)
         run(["%sobjcopy" % CROSS_COMPILE, "-O", "binary",
-             "%s/aarch64-unknown-none-softfloat/release/fvp" % OUT,
+             "%s/aarch64-unknown-none-softfloat/release/islet-rmm" % OUT,
              "%s/rmm.bin" % OUT],
              cwd=ROOT)
     elif rmm == "tf-rmm":

--- a/scripts/qemu-cca
+++ b/scripts/qemu-cca
@@ -169,7 +169,6 @@ def prepare_bootloaders(rmm, bl33, hes):
         print("[WARN] boot loader build arguments are not defined yet")
         sys.exit(1)
     else:
-         # We don't want to build secure OS. Set BL32 empty
         if rmm == "islet":
             args.append("RMM_BIN=%s/rmm.bin" % OUT)
         make(BUILD_SCRIPT, args)
@@ -182,7 +181,7 @@ def prepare_bootloaders(rmm, bl33, hes):
         make(TF_A_RSS, args)
         outdir = os.path.join(TF_A_RSS, "build/qemu/release")
     else:
-        outdir = os.path.join(TF_A, "build/qemu/release")
+        outdir = os.path.join(TF_A, "build/qemu/debug")
 
     for bootloader in bl_list:
         outbin = os.path.join(outdir, bootloader)
@@ -213,6 +212,7 @@ def get_rmm_features(args):
             features += ["--features", "stat"]
         if args.normal_world == "acs":
             features += ["--features", "gst_page_table"]
+        features += ["--features", "qemu"]
 
     if features:
         print("[!] Setting", args.rmm, "features:", features)
@@ -224,14 +224,14 @@ def prepare_rmm(rmm, features):
     print("[!] Building realm management monitor...: %s" % rmm)
 
     if rmm == "islet":
-        print("[TODO] for %s" % rmm)
-        sys.exit(1) 
         args = ["cargo", "build", "--release"]
         args += features
 
-        run(args, cwd=RMM)
+        new_env = os.environ.copy()
+        new_env["PLATFORM"] = "qemu"
+        run(args, cwd=RMM, new_env=new_env)
         run(["%sobjcopy" % CROSS_COMPILE, "-O", "binary",
-             "%s/aarch64-unknown-none-softfloat/release/qemu" % OUT,
+             "%s/aarch64-unknown-none-softfloat/release/islet-rmm" % OUT,
              "%s/rmm.bin" % OUT],
              cwd=ROOT)
     elif rmm == "tf-rmm":

--- a/scripts/qemu-cca
+++ b/scripts/qemu-cca
@@ -181,7 +181,7 @@ def prepare_bootloaders(rmm, bl33, hes):
         make(TF_A_RSS, args)
         outdir = os.path.join(TF_A_RSS, "build/qemu/release")
     else:
-        outdir = os.path.join(TF_A, "build/qemu/debug")
+        outdir = os.path.join(TF_A, "build/qemu/release")
 
     for bootloader in bl_list:
         outbin = os.path.join(outdir, bootloader)
@@ -298,15 +298,18 @@ def run_qemu_tf_a_tests(debug):
     print("[TODO] Running qemu for tf-a-tests...")
     sys.exit(1)
 
-def run_qemu_linux(debug):
+def run_qemu_linux(rmm, debug):
     print("[!] Running qemu for linux...")
     args = default_optee_build_args("run-only")
+    if rmm == "islet":
+        args.append("EXTRA_CMDLINE=kvm-rme.save_host_context=1")
+        args.append("QEMU_LPA2=n")
 
     print("[!] RUNNING QEMU...")
     make(BUILD_SCRIPT, args)
 
 
-def run_qemu_linux_net(debug, host_ip, host_tap_ip, qemu_ip, qemu_tap_ip, realm_ip, route_ip, gateway, ifname):
+def run_qemu_linux_net(rmm, debug, host_ip, host_tap_ip, qemu_ip, qemu_tap_ip, realm_ip, route_ip, gateway, ifname):
     print("[TODO] Running qemu for linux with the tap network..", )
     sys.exit(1)
 
@@ -505,10 +508,10 @@ if __name__ == "__main__":
         run_qemu_tf_a_tests(args.debug)
 
     if not args.build_only and args.normal_world == "linux":
-        run_qemu_linux(args.debug)
+        run_qemu_linux(args.rmm, args.debug)
 
     if not args.build_only and args.normal_world == "linux-net":
-        run_qemu_linux_net(args.debug, args.host_ip, args.host_tap_ip, args.fvp_ip, args.fvp_tap_ip, args.realm_ip, args.route_ip, args.gateway, args.ifname)
+        run_qemu_linux_net(args.rmm, args.debug, args.host_ip, args.host_tap_ip, args.fvp_ip, args.fvp_tap_ip, args.realm_ip, args.route_ip, args.gateway, args.ifname)
 
     if not args.build_only and args.normal_world == "acs":
         run_qemu_acs(args.debug)


### PR DESCRIPTION
1. Use manifest provided by the EL3 on RMM's boot
    -  Move aarch64 common code in  plat/fvp/src to plat/src.
    - Place fvp and qemu specific code in plat/fvp and plat/qemu.
    - Get NS DRAM layout from the manifest provided by the EL3
       on RMM's entry.
       - granule : removed fvp specific dram layout
       - mm : Use the el3-shared buf memory addr in layout
              instead from the config.
       - rmm_el3: removed hardcoded addr (RMM_SHARED_BUFFER_ADDR).
    - TODO:   get the shared buf address holding the manifest from the rmm boot args (x3)
                 Leave it as out of the scope in this PR)

2.   cpuid: platform specific implementation
     - Different affinity levels in mpidr_el1 are used in FVP and QEMU.
          -  On FVP, mpidr_el1 is increased updating AFF1 and AFF1
              0x81000000, 0x81000100, 0x81000200, 0x81000300...
          -  On QEMU, AFF0 and AFF1 is used instead.
              0x80000000, 0x80000001, 0x80000002, 0x80000003...
3.  rmi/rsi: get fid after removing sve hint
     - qemu turns sve feature on and this makes smccc 1.3 embed sve hint bit at bits 16 
      in RMM commands. Remove it and get fid.


4.  granule/array: adjust granule status table size
    - Current table size only works for fvp, but not for qemu.
    - Define max dram size in config.rs and caculate its addressable size based on the config.

5.   pl011: correct TXFF bit check in putc()
     - Without fixing it, no console for rmm is shown  and it is stuck at the while loop in putc()
     - 
6.  qemu-cca: adjust qemu execution args
    Deleiver following options to optee-build/qemu_v8_cca
    - tf-rmm requires lpa2 while islet doesn't.
       islet: -M lpa2=off
    - linux with islet requires extra boot command
       kvm-rme.save_host_context=1


