### PR TITLE
smc: preserve x4 if unused

### DIFF
--- a/rmm/src/event/mod.rs
+++ b/rmm/src/event/mod.rs
@@ -27,6 +27,7 @@ pub struct Context {
     pub arg: Vec<usize>,
     pub ret: Vec<usize>,
     pub sve_hint: bool,
+    pub x4: u64,
 }
 
 impl Context {
@@ -36,6 +37,7 @@ impl Context {
             arg: Vec::new(),
             ret: Vec::new(),
             sve_hint: false,
+            x4: 0,
         }
     }
 

--- a/rmm/src/monitor.rs
+++ b/rmm/src/monitor.rs
@@ -109,8 +109,14 @@ impl Monitor {
                 &ctx.ret
             );
 
-            ctx.arg.clear();
-            ctx.arg.extend_from_slice(&ctx.ret[..]);
+            // SMC calling convention requires x4-x7 to be preserved unless used.
+            // Since the rmmd in EL3 takes care of preserving x5-x7,
+            // we only restore x4.
+            ctx.arg.resize(5, 0);
+            ctx.arg[..ctx.ret.len()].copy_from_slice(&ctx.ret[..]);
+            if ctx.ret.len() < 5 {
+                ctx.arg[4] = ctx.x4 as usize;
+            }
 
             #[cfg(kani)]
             // the below is a proof helper

--- a/rmm/src/rmi/constraint.rs
+++ b/rmm/src/rmi/constraint.rs
@@ -62,6 +62,10 @@ pub fn validate(cmd: Command, arg: &[usize]) -> Context {
     let fid = cmd & !SMCCC_1_3_SVE_HINT;
     if let Some(c) = pick(fid) {
         let mut ctx = Context::new(fid);
+        // SMC calling convention requires x4-x7 to be preserved unless used.
+        // Since the rmmd in EL3 takes care of preserving x5-x7,
+        // we only store x4.
+        ctx.x4 = arg[3] as u64;
         ctx.init_arg(&arg[..(c.arg_num - 1)]);
         ctx.resize_ret(c.ret_num);
         if cmd & SMCCC_1_3_SVE_HINT != 0 {


### PR DESCRIPTION
According to smccc,
registers X4-X17 must be preserved unless they contain results. Since X5-X17 and X18-X30 are preserved by EL3, preserve x4 only at RMM.

[Problem]
If nw-linux is configured with the 'defconfig' instead of the 'host' file, the host linux gives errors.
--------------------------NW log on launch_realm.sh----------------------------------
[   64.936201] Unable to handle kernel paging request at virtual address fffffdffbf000008
[   64.936729] Mem abort info:
[   64.936848]   ESR = 0x0000000096000006
[   64.936997]   EC = 0x25: DABT (current EL), IL = 32 bits
[   64.937164]   SET = 0, FnV = 0
[   64.937310]   EA = 0, S1PTW = 0
[   64.937445]   FSC = 0x06: level 2 translation fault
[   64.937606] Data abort info:
[   64.937737]   ISV = 0, ISS = 0x00000006, ISS2 = 0x00000000
[   64.937891]   CM = 0, WnR = 0, TnD = 0, TagAccess = 0
[   64.938048]   GCS = 0, Overlay = 0, DirtyBit = 0, Xs = 0
[   64.938246] swapper pgtable: 4k pages, 48-bit VAs, pgdp=00000002346ad000
[   64.938451] [fffffdffbf000008] pgd=0000000000000000, p4d=100000023ed54003, pud=1000000100af9003, pmd=0000000000000000
[   64.939335] Internal error: Oops: 0000000096000006 [#1] PREEMPT SMP
[   64.939589] Modules linked in:
[   64.939931] CPU: 0 UID: 0 PID: 98 Comm: kvm-vcpu-0 Not tainted 6.12.0-rc1-g5d210abd4e2a-dirty #21
[   64.940252] Hardware name: QEMU QEMU Virtual Machine, BIOS unknown 02/02/2022
[   64.940536] pstate: 61402009 (nZCv daif +PAN -UAO -TCO +DIT -SSBS BTYPE=--)
[   64.940716] pc : realm_unmap_range_private+0x1b0/0x290
[   64.941236] lr : realm_unmap_range_private+0x264/0x290
[   64.941373] sp : ffff8000843939b0
[   64.941478] x29: ffff8000843939b0 x28: 0000000088401000 x27: ffffc1ffc0000000
[   64.941734] x26: 00000000c4000152 x25: 000000008c400000 x24: ffffffffffffffff
[   64.941936] x23: 00000000c4000155 x22: 000000010365c000 x21: ffff800082fbde28
[   64.942138] x20: 0000000088400000 x19: 0000000000000000 x18: 00000000cc863ada
[   64.942341] x17: 000000000000001c x16: 0000000000000004 x15: 0000001a97d6880e
[   64.942539] x14: 00000000000003d2 x13: 0000000000000000 x12: 0000000000000000
[   64.942763] x11: 0000000000000000 x10: ca756594741bffd9 x9 : 1a319047807a0026
[   64.943134] x8 : 0000000000001400 x7 : 0000000000000000 x6 : 00000000000012c0
[   64.943408] x5 : 0010000000000000 x4 : 0000000000000000 x3 : 0000000000000000
[   64.943933] x2 : 0000000000000000 x1 : 0000000000000000 x0 : fffffdffbf000000
[   64.944703] Call trace:
[   64.944811]  realm_unmap_range_private+0x1b0/0x290
[   64.945019]  realm_set_ipa_state+0x160/0x2cc
[   64.945375]  handle_rec_exit+0x368/0x480
[   64.945591]  kvm_arch_vcpu_ioctl_run+0x4d0/0x8bc
[   64.945754]  kvm_vcpu_ioctl+0x2f0/0x95c
[   64.945863]  __arm64_sys_ioctl+0xa8/0xec
[   64.945973]  invoke_syscall+0x48/0x110
[   64.946090]  el0_svc_common.constprop.0+0x40/0xe8
[   64.946248]  do_el0_svc+0x20/0x2c
[   64.946360]  el0_svc+0x34/0xdc
[   64.946470]  el0t_64_sync_handler+0x13c/0x158
[   64.946601]  el0t_64_sync+0x190/0x194
[   64.946845] Code: d34cfc84 f9433800 cb803080 8b001b60 (f9400401) 
[   64.947261] ---[ end trace 0000000000000000 ]---
[   65.320833] note: kvm-vcpu-0[98] exited with preempt_count 1


[Reason]
As seen above, values x4, x3, and x2 are set to zero, which are written by RMM as part of the unused regs for the smc replying to the RMI_GRANULE_UNDELTEGATE call.
Howerver, smc calling convention requires x4-x7 preserved if unused.
If nw-linux is configured with defconfig, it uses x4 right after smc. The overwritten x4 with the value 0 makes operation after the RMI call fails in nw.
