### PR TITLE
miri: re-enable rmi_rtt_map_unprotected_positive

### DIFF
--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -462,7 +462,7 @@ mod test {
     // Source: https://github.com/ARM-software/cca-rmm-acs
     // Test Case: cmd_rtt_map_unprotected
     // Covered RMIs: RTT_MAP_UNPROTECTED, RTT_UNMAP_UNPROTECTED
-    // #[test] TODO: enable this test after fixing it
+    #[test]
     fn rmi_rtt_map_unprotected_positive() {
         let rd = realm_create();
 
@@ -472,7 +472,7 @@ mod test {
         let ipa = IPA_ADDR_UNPROTECTED_UNASSIGNED;
         let level = MAP_LEVEL;
         let ns = mock::host::alloc_granule(IDX_NS_DESC);
-        let desc = ns | ATTR_NORMAL_WB_WA_RA | ATTR_STAGE2_AP_RW | ATTR_INNER_SHARED;
+        let desc = ns | ATTR_NORMAL_WB_WA_RA | ATTR_STAGE2_AP_RW;
 
         let ret = rmi::<RTT_MAP_UNPROTECTED>(&[rd, ipa, level, desc]);
         assert_eq!(ret[0], SUCCESS);


### PR DESCRIPTION
    Update out_desc check condition according to the changes made
    to the state_unprot success condition for RMI_RTT_READ_ENTRY.
    (Remove the shareability property.)
    - CCAv1.0-eac5:
     pre: walk.rtte.state == ASSIGNED_NS
     post: (rtte.MemAttr == walk.rtte.MemAttr
            && rtte.S2AP == walk.rtte.S2AP
            && rtte.SH == walk.rtte.SH
            && rtte.addr == walk.rtte.addr)
    - CCAv1.0-rel0
     pre: walk.rtte.state == ASSIGNED_NS
     post: (rtte.MemAttr == walk.rtte.MemAttr
            && rtte.S2AP == walk.rtte.S2AP
            && rtte.addr == walk.rtte.addr)
