### PR TITLE
Move rec independent code from rec

### DIFF
--- a/plat/fvp/plat.rs
+++ b/plat/fvp/plat.rs
@@ -3,4 +3,4 @@ pub const UART_BASE: usize = 0x1C0C_0000;
 //pub const UART_BAUDRATE: usize = 115200;
 //pub const UART_CLK_IN_HZ: usize = 24000000;
 // Last page of Realm PAS assigned to RMM contains manifest written by EL3
-pub const EL3_SHARED_BUF: u64 = 0xFFBFF000;
+// pub const EL3_SHARED_BUF: u64 = 0xFFBFF000;

--- a/plat/qemu/plat.rs
+++ b/plat/qemu/plat.rs
@@ -3,4 +3,4 @@ pub const UART_BASE: usize = 0x900_0000;
 //pub const UART_BAUDRATE: usize = 115200;
 //pub const UART_CLK_IN_HZ: usize = 1;
 // Last page of Realm PAS assigned to RMM contains manifest written by EL3
-pub const EL3_SHARED_BUF: u64 = 0x428F_F000;
+//pub const EL3_SHARED_BUF: u64 = 0x428F_F000;

--- a/rmm/src/gic.rs
+++ b/rmm/src/gic.rs
@@ -1,0 +1,185 @@
+use aarch64_cpu::registers::*;
+use lazy_static::lazy_static;
+
+pub const ICH_HCR_EL2_INIT: u64 = (ICH_HCR_EL2::En.mask << ICH_HCR_EL2::En.shift)
+    + (ICH_HCR_EL2::vSGIEOICount.mask << ICH_HCR_EL2::vSGIEOICount.shift)
+    + (ICH_HCR_EL2::DVIM.mask << ICH_HCR_EL2::DVIM.shift);
+
+// Interrupt Controller List Registers (ICH_LR)
+const ICH_LR_PRIORITY_WIDTH: u64 = 8;
+
+pub const ICH_HCR_EL2_NS_MASK: u64 = (ICH_HCR_EL2::UIE.mask << ICH_HCR_EL2::UIE.shift)
+    | (ICH_HCR_EL2::LRENPIE.mask << ICH_HCR_EL2::LRENPIE.shift)
+    | (ICH_HCR_EL2::NPIE.mask << ICH_HCR_EL2::NPIE.shift)
+    | (ICH_HCR_EL2::VGrp1DIE.mask << ICH_HCR_EL2::VGrp1DIE.shift)
+    | (ICH_HCR_EL2::VGrp1EIE.mask << ICH_HCR_EL2::VGrp1EIE.shift)
+    | (ICH_HCR_EL2::VGrp0DIE.mask << ICH_HCR_EL2::VGrp0DIE.shift)
+    | (ICH_HCR_EL2::VGrp0EIE.mask << ICH_HCR_EL2::VGrp0EIE.shift)
+    | (ICH_HCR_EL2::TDIR.mask << ICH_HCR_EL2::TDIR.shift);
+
+const ICH_HCR_EL2_EOI_COUNT_WIDTH: usize = 5;
+pub const ICH_HCR_EL2_EOI_COUNT_MASK: u64 =
+    ((!0u64) >> (64 - ICH_HCR_EL2_EOI_COUNT_WIDTH)) << ICH_HCR_EL2::EOIcount.shift;
+
+const MAX_SPI_ID: u64 = 1019;
+
+const MIN_EPPI_ID: u64 = 1056;
+const MAX_EPPI_ID: u64 = 1119;
+
+const MIN_ESPI_ID: u64 = 4096;
+const MAX_ESPI_ID: u64 = 5119;
+
+const MIN_LPI_ID: u64 = 8192;
+
+#[allow(dead_code)]
+pub struct GicFeatures {
+    pub nr_lrs: usize,
+    pub nr_aprs: usize,
+    pub pri_res0_mask: u64,
+    pub max_vintid: u64,
+    pub ext_range: bool,
+}
+
+lazy_static! {
+    pub static ref GIC_FEATURES: GicFeatures = {
+        trace!("read gic features");
+        let nr_lrs = ICH_VTR_EL2.read(ICH_VTR_EL2::ListRegs) as usize;
+        trace!("nr_lrs (LIST) {}", nr_lrs);
+        let id = ICH_VTR_EL2.read(ICH_VTR_EL2::IDbits);
+        let max_vintid = if id == 0 {
+            (1u64 << 16) - 1
+        } else {
+            (1u64 << 24) - 1
+        };
+        trace!("id {} max_vintid {}", id, max_vintid);
+        let pre = ICH_VTR_EL2.read(ICH_VTR_EL2::PREbits) + 1;
+        let nr_aprs = (1 << (pre - 5)) - 1;
+        trace!("pre {}, nr_aprs {}", pre, nr_aprs);
+        let pri = ICH_VTR_EL2.read(ICH_VTR_EL2::PRIbits) + 1;
+        let pri_res0_mask = (1u64 << (ICH_LR_PRIORITY_WIDTH - pri)) - 1;
+        trace!("pri {} pri_res0_mask {}", pri, pri_res0_mask);
+        let ext_range = ICC_CTLR_EL1.read(ICC_CTLR_EL1::ExtRange) != 0;
+        trace!("icc_ctlr ext_range {}", ext_range);
+        GicFeatures {
+            nr_lrs,
+            nr_aprs,
+            pri_res0_mask,
+            max_vintid,
+            ext_range,
+        }
+    };
+}
+
+pub fn nr_lrs() -> usize {
+    GIC_FEATURES.nr_lrs
+}
+
+pub fn nr_aprs() -> usize {
+    GIC_FEATURES.nr_aprs
+}
+
+pub fn pri_res0_mask() -> u64 {
+    GIC_FEATURES.pri_res0_mask
+}
+
+pub fn set_lr(i: usize, val: u64) {
+    match i {
+        0 => ICH_LR0_EL2.set(val),
+        1 => ICH_LR1_EL2.set(val),
+        2 => ICH_LR2_EL2.set(val),
+        3 => ICH_LR3_EL2.set(val),
+        4 => ICH_LR4_EL2.set(val),
+        5 => ICH_LR5_EL2.set(val),
+        6 => ICH_LR6_EL2.set(val),
+        7 => ICH_LR7_EL2.set(val),
+        8 => ICH_LR8_EL2.set(val),
+        9 => ICH_LR9_EL2.set(val),
+        10 => ICH_LR10_EL2.set(val),
+        11 => ICH_LR11_EL2.set(val),
+        12 => ICH_LR12_EL2.set(val),
+        13 => ICH_LR13_EL2.set(val),
+        14 => ICH_LR14_EL2.set(val),
+        15 => ICH_LR15_EL2.set(val),
+        _ => {}
+    }
+}
+
+pub fn set_ap0r(i: usize, val: u64) {
+    match i {
+        0 => ICH_AP0R0_EL2.set(val),
+        1 => ICH_AP0R1_EL2.set(val),
+        2 => ICH_AP0R2_EL2.set(val),
+        3 => ICH_AP0R3_EL2.set(val),
+        _ => {}
+    }
+}
+
+pub fn set_ap1r(i: usize, val: u64) {
+    match i {
+        0 => ICH_AP1R0_EL2.set(val),
+        1 => ICH_AP1R1_EL2.set(val),
+        2 => ICH_AP1R2_EL2.set(val),
+        3 => ICH_AP1R3_EL2.set(val),
+        _ => {}
+    }
+}
+
+pub fn get_lr(i: usize) -> u64 {
+    match i {
+        0 => ICH_LR0_EL2.get(),
+        1 => ICH_LR1_EL2.get(),
+        2 => ICH_LR2_EL2.get(),
+        3 => ICH_LR3_EL2.get(),
+        4 => ICH_LR4_EL2.get(),
+        5 => ICH_LR5_EL2.get(),
+        6 => ICH_LR6_EL2.get(),
+        7 => ICH_LR7_EL2.get(),
+        8 => ICH_LR8_EL2.get(),
+        9 => ICH_LR9_EL2.get(),
+        10 => ICH_LR10_EL2.get(),
+        11 => ICH_LR11_EL2.get(),
+        12 => ICH_LR12_EL2.get(),
+        13 => ICH_LR13_EL2.get(),
+        14 => ICH_LR14_EL2.get(),
+        15 => ICH_LR15_EL2.get(),
+        _ => unreachable!(),
+    }
+}
+
+pub fn get_ap0r(i: usize) -> u64 {
+    match i {
+        0 => ICH_AP0R0_EL2.get(),
+        1 => ICH_AP0R1_EL2.get(),
+        2 => ICH_AP0R2_EL2.get(),
+        3 => ICH_AP0R3_EL2.get(),
+        _ => unreachable!(),
+    }
+}
+
+pub fn get_ap1r(i: usize) -> u64 {
+    match i {
+        0 => ICH_AP1R0_EL2.get(),
+        1 => ICH_AP1R1_EL2.get(),
+        2 => ICH_AP1R2_EL2.get(),
+        3 => ICH_AP1R3_EL2.get(),
+        _ => unreachable!(),
+    }
+}
+
+pub fn valid_vintid(intid: u64) -> bool {
+    /* Check for INTID [0..1019] and [8192..] */
+    if intid <= MAX_SPI_ID || (intid >= MIN_LPI_ID && intid <= GIC_FEATURES.max_vintid) {
+        return true;
+    }
+
+    /*
+     * If extended INTID range sopported, check for
+     * Extended PPI [1056..1119] and Extended SPI [4096..5119]
+     */
+    if GIC_FEATURES.ext_range {
+        return (intid >= MIN_EPPI_ID && intid <= MAX_EPPI_ID)
+            || (intid >= MIN_ESPI_ID && intid <= MAX_ESPI_ID);
+    }
+
+    false
+}

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod cpu;
 pub(crate) mod event;
 pub mod exception;
+pub mod gic;
 #[macro_use]
 pub mod granule;
 #[macro_use]

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -23,6 +23,7 @@ pub mod realm;
 pub mod rec;
 pub mod rmi;
 pub mod rsi;
+pub mod simd;
 #[cfg(feature = "stat")]
 pub mod stat;
 #[cfg(any(test, miri))]

--- a/rmm/src/realm/rd.rs
+++ b/rmm/src/realm/rd.rs
@@ -2,7 +2,7 @@ use vmsa::guard::Content;
 
 use crate::measurement::{Measurement, MEASUREMENTS_SLOT_NR};
 use crate::realm::mm::IPATranslation;
-use crate::rec::simd::SimdConfig;
+use crate::simd::SimdConfig;
 use alloc::boxed::Box;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::sync::Arc;

--- a/rmm/src/rec/gic.rs
+++ b/rmm/src/rec/gic.rs
@@ -1,174 +1,19 @@
 use super::Rec;
+use crate::gic::*;
 use crate::rmi::error::Error;
 use crate::rmi::rec::run::Run;
 
 use aarch64_cpu::registers::*;
-use lazy_static::lazy_static;
-
-// Interrupt Controller List Registers (ICH_LR)
-const ICH_LR_PRIORITY_WIDTH: u64 = 8;
-
-const ICH_HCR_EL2_NS_MASK: u64 = (ICH_HCR_EL2::UIE.mask << ICH_HCR_EL2::UIE.shift)
-    | (ICH_HCR_EL2::LRENPIE.mask << ICH_HCR_EL2::LRENPIE.shift)
-    | (ICH_HCR_EL2::NPIE.mask << ICH_HCR_EL2::NPIE.shift)
-    | (ICH_HCR_EL2::VGrp1DIE.mask << ICH_HCR_EL2::VGrp1DIE.shift)
-    | (ICH_HCR_EL2::VGrp1EIE.mask << ICH_HCR_EL2::VGrp1EIE.shift)
-    | (ICH_HCR_EL2::VGrp0DIE.mask << ICH_HCR_EL2::VGrp0DIE.shift)
-    | (ICH_HCR_EL2::VGrp0EIE.mask << ICH_HCR_EL2::VGrp0EIE.shift)
-    | (ICH_HCR_EL2::TDIR.mask << ICH_HCR_EL2::TDIR.shift);
-
-const ICH_HCR_EL2_EOI_COUNT_WIDTH: usize = 5;
-const ICH_HCR_EL2_EOI_COUNT_MASK: u64 =
-    ((!0u64) >> (64 - ICH_HCR_EL2_EOI_COUNT_WIDTH)) << ICH_HCR_EL2::EOIcount.shift;
-
-const MAX_SPI_ID: u64 = 1019;
-
-const MIN_EPPI_ID: u64 = 1056;
-const MAX_EPPI_ID: u64 = 1119;
-
-const MIN_ESPI_ID: u64 = 4096;
-const MAX_ESPI_ID: u64 = 5119;
-
-const MIN_LPI_ID: u64 = 8192;
-
-#[allow(dead_code)]
-pub struct GicFeatures {
-    pub nr_lrs: usize,
-    pub nr_aprs: usize,
-    pub pri_res0_mask: u64,
-    pub max_vintid: u64,
-    pub ext_range: bool,
-}
-
-lazy_static! {
-    pub static ref GIC_FEATURES: GicFeatures = {
-        trace!("read gic features");
-        let nr_lrs = ICH_VTR_EL2.read(ICH_VTR_EL2::ListRegs) as usize;
-        trace!("nr_lrs (LIST) {}", nr_lrs);
-        let id = ICH_VTR_EL2.read(ICH_VTR_EL2::IDbits);
-        let max_vintid = if id == 0 {
-            (1u64 << 16) - 1
-        } else {
-            (1u64 << 24) - 1
-        };
-        trace!("id {} max_vintid {}", id, max_vintid);
-        let pre = ICH_VTR_EL2.read(ICH_VTR_EL2::PREbits) + 1;
-        let nr_aprs = (1 << (pre - 5)) - 1;
-        trace!("pre {}, nr_aprs {}", pre, nr_aprs);
-        let pri = ICH_VTR_EL2.read(ICH_VTR_EL2::PRIbits) + 1;
-        let pri_res0_mask = (1u64 << (ICH_LR_PRIORITY_WIDTH - pri)) - 1;
-        trace!("pri {} pri_res0_mask {}", pri, pri_res0_mask);
-        let ext_range = ICC_CTLR_EL1.read(ICC_CTLR_EL1::ExtRange) != 0;
-        trace!("icc_ctlr ext_range {}", ext_range);
-        GicFeatures {
-            nr_lrs,
-            nr_aprs,
-            pri_res0_mask,
-            max_vintid,
-            ext_range,
-        }
-    };
-}
-
-pub fn nr_lrs() -> usize {
-    GIC_FEATURES.nr_lrs
-}
 
 pub fn init_gic(rec: &mut Rec<'_>) {
     let gic_state = &mut rec.context.gic_state;
-    gic_state.ich_hcr_el2 = (ICH_HCR_EL2::En.mask << ICH_HCR_EL2::En.shift)
-        + (ICH_HCR_EL2::vSGIEOICount.mask << ICH_HCR_EL2::vSGIEOICount.shift)
-        + (ICH_HCR_EL2::DVIM.mask << ICH_HCR_EL2::DVIM.shift)
-}
-
-fn set_lr(i: usize, val: u64) {
-    match i {
-        0 => ICH_LR0_EL2.set(val),
-        1 => ICH_LR1_EL2.set(val),
-        2 => ICH_LR2_EL2.set(val),
-        3 => ICH_LR3_EL2.set(val),
-        4 => ICH_LR4_EL2.set(val),
-        5 => ICH_LR5_EL2.set(val),
-        6 => ICH_LR6_EL2.set(val),
-        7 => ICH_LR7_EL2.set(val),
-        8 => ICH_LR8_EL2.set(val),
-        9 => ICH_LR9_EL2.set(val),
-        10 => ICH_LR10_EL2.set(val),
-        11 => ICH_LR11_EL2.set(val),
-        12 => ICH_LR12_EL2.set(val),
-        13 => ICH_LR13_EL2.set(val),
-        14 => ICH_LR14_EL2.set(val),
-        15 => ICH_LR15_EL2.set(val),
-        _ => {}
-    }
-}
-
-fn set_ap0r(i: usize, val: u64) {
-    match i {
-        0 => ICH_AP0R0_EL2.set(val),
-        1 => ICH_AP0R1_EL2.set(val),
-        2 => ICH_AP0R2_EL2.set(val),
-        3 => ICH_AP0R3_EL2.set(val),
-        _ => {}
-    }
-}
-
-fn set_ap1r(i: usize, val: u64) {
-    match i {
-        0 => ICH_AP1R0_EL2.set(val),
-        1 => ICH_AP1R1_EL2.set(val),
-        2 => ICH_AP1R2_EL2.set(val),
-        3 => ICH_AP1R3_EL2.set(val),
-        _ => {}
-    }
-}
-
-fn get_lr(i: usize) -> u64 {
-    match i {
-        0 => ICH_LR0_EL2.get(),
-        1 => ICH_LR1_EL2.get(),
-        2 => ICH_LR2_EL2.get(),
-        3 => ICH_LR3_EL2.get(),
-        4 => ICH_LR4_EL2.get(),
-        5 => ICH_LR5_EL2.get(),
-        6 => ICH_LR6_EL2.get(),
-        7 => ICH_LR7_EL2.get(),
-        8 => ICH_LR8_EL2.get(),
-        9 => ICH_LR9_EL2.get(),
-        10 => ICH_LR10_EL2.get(),
-        11 => ICH_LR11_EL2.get(),
-        12 => ICH_LR12_EL2.get(),
-        13 => ICH_LR13_EL2.get(),
-        14 => ICH_LR14_EL2.get(),
-        15 => ICH_LR15_EL2.get(),
-        _ => unreachable!(),
-    }
-}
-
-fn get_ap0r(i: usize) -> u64 {
-    match i {
-        0 => ICH_AP0R0_EL2.get(),
-        1 => ICH_AP0R1_EL2.get(),
-        2 => ICH_AP0R2_EL2.get(),
-        3 => ICH_AP0R3_EL2.get(),
-        _ => unreachable!(),
-    }
-}
-
-fn get_ap1r(i: usize) -> u64 {
-    match i {
-        0 => ICH_AP1R0_EL2.get(),
-        1 => ICH_AP1R1_EL2.get(),
-        2 => ICH_AP1R2_EL2.get(),
-        3 => ICH_AP1R3_EL2.get(),
-        _ => unreachable!(),
-    }
+    gic_state.ich_hcr_el2 = ICH_HCR_EL2_INIT;
 }
 
 pub fn restore_state(rec: &Rec<'_>) {
     let gic_state = &rec.context.gic_state;
-    let nr_lrs = GIC_FEATURES.nr_lrs;
-    let nr_aprs = GIC_FEATURES.nr_aprs;
+    let nr_lrs = nr_lrs();
+    let nr_aprs = nr_aprs();
 
     for i in 0..=nr_lrs {
         set_lr(i, gic_state.ich_lr_el2[i]);
@@ -183,8 +28,8 @@ pub fn restore_state(rec: &Rec<'_>) {
 
 pub fn save_state(rec: &mut Rec<'_>) {
     let gic_state = &mut rec.context.gic_state;
-    let nr_lrs = GIC_FEATURES.nr_lrs;
-    let nr_aprs = GIC_FEATURES.nr_aprs;
+    let nr_lrs = nr_lrs();
+    let nr_aprs = nr_aprs();
 
     for i in 0..=nr_lrs {
         gic_state.ich_lr_el2[i] = get_lr(i);
@@ -203,7 +48,7 @@ pub fn save_state(rec: &mut Rec<'_>) {
 
 pub fn receive_state_from_host(rec: &mut Rec<'_>, run: &Run) -> Result<(), Error> {
     let gic_state = &mut rec.context.gic_state;
-    let nr_lrs = GIC_FEATURES.nr_lrs;
+    let nr_lrs = nr_lrs();
 
     gic_state.ich_lr_el2[..nr_lrs].copy_from_slice(&run.entry_gic_lrs()[..nr_lrs]);
     gic_state.ich_hcr_el2 &= !ICH_HCR_EL2_NS_MASK;
@@ -213,31 +58,13 @@ pub fn receive_state_from_host(rec: &mut Rec<'_>, run: &Run) -> Result<(), Error
 
 pub fn send_state_to_host(rec: &Rec<'_>, run: &mut Run) -> Result<(), Error> {
     let gic_state = &rec.context.gic_state;
-    let nr_lrs = GIC_FEATURES.nr_lrs;
+    let nr_lrs = nr_lrs();
 
     run.exit_gic_lrs_mut()[..nr_lrs].copy_from_slice(&gic_state.ich_lr_el2[..nr_lrs]);
     run.set_gic_misr(gic_state.ich_misr_el2);
     run.set_gic_vmcr(gic_state.ich_vmcr_el2);
     run.set_gic_hcr(gic_state.ich_hcr_el2 & (ICH_HCR_EL2_EOI_COUNT_MASK | ICH_HCR_EL2_NS_MASK));
     Ok(())
-}
-
-fn valid_vintid(intid: u64) -> bool {
-    /* Check for INTID [0..1019] and [8192..] */
-    if intid <= MAX_SPI_ID || (intid >= MIN_LPI_ID && intid <= GIC_FEATURES.max_vintid) {
-        return true;
-    }
-
-    /*
-     * If extended INTID range sopported, check for
-     * Extended PPI [1056..1119] and Extended SPI [4096..5119]
-     */
-    if GIC_FEATURES.ext_range {
-        return (intid >= MIN_EPPI_ID && intid <= MAX_EPPI_ID)
-            || (intid >= MIN_ESPI_ID && intid <= MAX_ESPI_ID);
-    }
-
-    false
 }
 
 pub fn validate_state(run: &Run) -> bool {
@@ -248,7 +75,7 @@ pub fn validate_state(run: &Run) -> bool {
         return false;
     }
 
-    for i in 0..GIC_FEATURES.nr_lrs {
+    for i in 0..nr_lrs() {
         let lrs = run.entry_gic_lrs();
         let lr = lrs[i];
 
@@ -269,7 +96,7 @@ pub fn validate_state(run: &Run) -> bool {
         /* The RMM Specification imposes the constraint that HW == '0' */
         if hw != 0
             /* Check RES0 bits in the Priority field */
-            || priority & GIC_FEATURES.pri_res0_mask != 0
+            || priority & pri_res0_mask() != 0
             /* Only the EOI bit in the pINTID is allowed to be set */
             || lr & only_eoi != 0
             /* Check if vINTID is in the valid range */
@@ -282,7 +109,7 @@ pub fn validate_state(run: &Run) -> bool {
          * Behavior is UNPREDICTABLE if two or more List Registers
          * specify the same vINTID.
          */
-        for j in i + 1..=GIC_FEATURES.nr_lrs {
+        for j in i + 1..=nr_lrs() {
             let lrs = run.entry_gic_lrs();
             let lr = lrs[j];
 

--- a/rmm/src/rec/simd.rs
+++ b/rmm/src/rec/simd.rs
@@ -1,6 +1,5 @@
-use aarch64_cpu::registers::ID_AA64PFR0_EL1;
 use aarch64_cpu::registers::{Readable, Writeable};
-use armv9a::regs::{CPTR_EL2, ID_AA64PFR1_SME_EL1, SMCR_EL2, ZCR_EL1, ZCR_EL2};
+use armv9a::regs::{CPTR_EL2, ZCR_EL1, ZCR_EL2};
 use core::arch::asm;
 use core::array::from_fn;
 use lazy_static::lazy_static;
@@ -11,26 +10,7 @@ use crate::config::NUM_OF_CPU;
 use crate::cpu::get_cpu_id;
 use crate::realm::rd::Rd;
 use crate::rmi::error::Error;
-
-// Vector length (VL) = size of a Z-register in bytes
-// Vector quadwords (VQ) = size of a Z-register in units of 128 bits
-// Minimum length of a SVE vector: 128 bits
-const ZCR_EL2_LEN_WIDTH: u64 = 4;
-const SVE_VQ_ARCH_MAX: u64 = (1 << ZCR_EL2_LEN_WIDTH) - 1;
-const QUARD_WORD: u64 = 128;
-
-#[derive(Default, Debug)]
-// SIMD configuration structure
-pub struct SimdConfig {
-    // SVE enabled flag
-    pub sve_en: bool,
-
-    // SVE vector length represented in quads
-    pub sve_vq: u64,
-
-    // SME enabled flag
-    pub sme_en: bool,
-}
+use crate::simd::SimdConfig;
 
 // SIMD context structure
 #[derive(Default, Debug)]
@@ -58,6 +38,11 @@ pub struct FpuRegs {
     pub fpcr: u64,
 }
 
+lazy_static! {
+    // TODO: storing ns simd context should be in the ns world, not in the realm world.
+    static ref NS_SIMD: [Mutex<SimdRegister>; NUM_OF_CPU] = from_fn(|_| Mutex::new(SimdRegister::default()));
+}
+
 // SVE registers
 const NUM_VECTOR_REGS: usize = 32;
 const NUM_PREDICATE_REGS: usize = 16;
@@ -71,57 +56,6 @@ pub struct SveRegs {
     pub ffr: u64,
     pub zcr_el2: u64,
     pub zcr_el12: u64,
-}
-
-lazy_static! {
-    // TODO: storing ns simd context should be in the ns world, not in the realm world.
-    static ref NS_SIMD: [Mutex<SimdRegister>; NUM_OF_CPU] = from_fn(|_| Mutex::new(SimdRegister::default()));
-    // Global SIMD configuration
-    static ref SIMD_CONFIG: SimdConfig =  {
-        // Initalize SVE
-        let mut sve_en: bool = false;
-        let mut sve_vq: u64 = 0;
-        let mut sme_en: bool = false;
-
-        trace!("Reading simd features");
-        #[cfg(not(any(test, miri, fuzzing)))]
-        if ID_AA64PFR0_EL1.is_set(ID_AA64PFR0_EL1::SVE) {
-            trace!("SVE is set");
-            // Get effective vl
-            //let _e_vl = ZCR_EL2.read(ZCR_EL2::LEN);
-            // Set to maximum
-            ZCR_EL2.write(ZCR_EL2::LEN.val(SVE_VQ_ARCH_MAX));
-            // Get vl in bytes
-            let vl_b: u64;
-            unsafe {
-                asm!("rdvl {}, #1", out(reg) vl_b);
-            }
-            sve_vq = ((vl_b << 3)/ QUARD_WORD) - 1;
-            sve_en = true;
-            trace!("sve_vq={:?}", sve_vq);
-        }
-
-        // init sme
-        #[cfg(not(any(test, miri, fuzzing)))]
-        if ID_AA64PFR1_SME_EL1.is_set(ID_AA64PFR1_SME_EL1::SME) {
-            trace!("SME is set");
-            // Find the architecturally permitted SVL
-            SMCR_EL2.write(SMCR_EL2::RAZWI.val(SMCR_EL2::RAZWI.mask) + SMCR_EL2::LEN.val(SMCR_EL2::LEN.mask));
-            let raz = SMCR_EL2.read(SMCR_EL2::RAZWI);
-            let len = SMCR_EL2.read(SMCR_EL2::LEN);
-            let sme_svq_arch_max = (raz << 4) + len;
-            trace!("sme_svq_arch_max={:?}", sme_svq_arch_max);
-
-            assert!(sme_svq_arch_max <= SVE_VQ_ARCH_MAX);
-            sme_en = true;
-        }
-
-        SimdConfig {
-            sve_en,
-            sve_vq,
-            sme_en,
-        }
-    };
 }
 
 // TODO: Save according to the hint in FID with SMCCCv1.3 or v1.4
@@ -276,22 +210,4 @@ pub fn save_state(rec: &mut Rec<'_>) {
     rec_simd.cptr_el2 =
         (CPTR_EL2::TAM::SET + CPTR_EL2::TSM::SET + CPTR_EL2::TFP::SET + CPTR_EL2::TZ::SET).value;
     CPTR_EL2.set(ns_simd.cptr_el2);
-}
-
-pub fn validate(en: bool, sve_vl: u64) -> bool {
-    if en && !SIMD_CONFIG.sve_en {
-        return false;
-    }
-    if sve_vl > SIMD_CONFIG.sve_vq {
-        return false;
-    }
-    true
-}
-
-pub fn sve_en() -> bool {
-    SIMD_CONFIG.sve_en
-}
-
-pub fn max_sve_vl() -> u64 {
-    SIMD_CONFIG.sve_vq
 }

--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -1,7 +1,7 @@
 use crate::event::RmiHandle;
+use crate::gic;
 use crate::listen;
 use crate::rec;
-use crate::rec::gic;
 use crate::rmi;
 use crate::simd;
 use armv9a::{define_bitfield, define_bits, define_mask};

--- a/rmm/src/rmi/features.rs
+++ b/rmm/src/rmi/features.rs
@@ -1,8 +1,9 @@
 use crate::event::RmiHandle;
 use crate::listen;
 use crate::rec;
-use crate::rec::{gic, simd};
+use crate::rec::gic;
 use crate::rmi;
+use crate::simd;
 use armv9a::{define_bitfield, define_bits, define_mask};
 
 extern crate alloc;

--- a/rmm/src/rmi/realm/params.rs
+++ b/rmm/src/rmi/realm/params.rs
@@ -2,10 +2,10 @@ use crate::const_assert_eq;
 use crate::granule::{GRANULE_SHIFT, GRANULE_SIZE};
 use crate::measurement::Hashable;
 use crate::realm::mm::rtt::{RTT_PAGE_LEVEL, RTT_STRIDE};
-use crate::rec::simd;
 use crate::rmi::error::Error;
 use crate::rmi::features;
 use crate::rmi::{HASH_ALGO_SHA256, HASH_ALGO_SHA512};
+use crate::simd;
 
 use armv9a::{define_bitfield, define_bits, define_mask};
 use autopadding::*;

--- a/rmm/src/simd.rs
+++ b/rmm/src/simd.rs
@@ -1,0 +1,92 @@
+use aarch64_cpu::registers::ID_AA64PFR0_EL1;
+use aarch64_cpu::registers::{Readable, Writeable};
+use armv9a::regs::{ID_AA64PFR1_SME_EL1, SMCR_EL2, ZCR_EL2};
+use core::arch::asm;
+use lazy_static::lazy_static;
+
+// Vector length (VL) = size of a Z-register in bytes
+// Vector quadwords (VQ) = size of a Z-register in units of 128 bits
+// Minimum length of a SVE vector: 128 bits
+const ZCR_EL2_LEN_WIDTH: u64 = 4;
+const SVE_VQ_ARCH_MAX: u64 = (1 << ZCR_EL2_LEN_WIDTH) - 1;
+const QUARD_WORD: u64 = 128;
+
+#[derive(Default, Debug)]
+// SIMD configuration structure
+pub struct SimdConfig {
+    // SVE enabled flag
+    pub sve_en: bool,
+
+    // SVE vector length represented in quads
+    pub sve_vq: u64,
+
+    // SME enabled flag
+    pub sme_en: bool,
+}
+
+lazy_static! {
+    // Global SIMD configuration
+    static ref SIMD_CONFIG: SimdConfig =  {
+        // Initalize SVE
+        let mut sve_en: bool = false;
+        let mut sve_vq: u64 = 0;
+        let mut sme_en: bool = false;
+
+        trace!("Reading simd features");
+        #[cfg(not(any(test, miri, fuzzing)))]
+        if ID_AA64PFR0_EL1.is_set(ID_AA64PFR0_EL1::SVE) {
+            trace!("SVE is set");
+            // Get effective vl
+            //let _e_vl = ZCR_EL2.read(ZCR_EL2::LEN);
+            // Set to maximum
+            ZCR_EL2.write(ZCR_EL2::LEN.val(SVE_VQ_ARCH_MAX));
+            // Get vl in bytes
+            let vl_b: u64;
+            unsafe {
+                asm!("rdvl {}, #1", out(reg) vl_b);
+            }
+            sve_vq = ((vl_b << 3)/ QUARD_WORD) - 1;
+            sve_en = true;
+            trace!("sve_vq={:?}", sve_vq);
+        }
+
+        // init sme
+        #[cfg(not(any(test, miri, fuzzing)))]
+        if ID_AA64PFR1_SME_EL1.is_set(ID_AA64PFR1_SME_EL1::SME) {
+            trace!("SME is set");
+            // Find the architecturally permitted SVL
+            SMCR_EL2.write(SMCR_EL2::RAZWI.val(SMCR_EL2::RAZWI.mask) + SMCR_EL2::LEN.val(SMCR_EL2::LEN.mask));
+            let raz = SMCR_EL2.read(SMCR_EL2::RAZWI);
+            let len = SMCR_EL2.read(SMCR_EL2::LEN);
+            let sme_svq_arch_max = (raz << 4) + len;
+            trace!("sme_svq_arch_max={:?}", sme_svq_arch_max);
+
+            assert!(sme_svq_arch_max <= SVE_VQ_ARCH_MAX);
+            sme_en = true;
+        }
+
+        SimdConfig {
+            sve_en,
+            sve_vq,
+            sme_en,
+        }
+    };
+}
+
+pub fn validate(en: bool, sve_vl: u64) -> bool {
+    if en && !SIMD_CONFIG.sve_en {
+        return false;
+    }
+    if sve_vl > SIMD_CONFIG.sve_vq {
+        return false;
+    }
+    true
+}
+
+pub fn sve_en() -> bool {
+    SIMD_CONFIG.sve_en
+}
+
+pub fn max_sve_vl() -> u64 {
+    SIMD_CONFIG.sve_vq
+}


### PR DESCRIPTION
1.  gic, smid code split
There was an opinion that gic and simd are better kept out of the 'rec' directory in a previous PR.
To meet in the middle, I moved gic and simd code  which are independent from the realm context to the upper directory.

2. use boot arguments provided by EL2 on rmm entry
- x0: cpuid
- x1: version (unused)
- x2: total core count (unused)
- x3: shared buf containing manifest