### PR TITLE
Fix errors discoverd during the miri/fuzz test.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,8 @@ jobs:
     - name: Run unsafe analyzer
       run: ./scripts/run-unsafe-analysis.sh
 
-#    - name: Run MIRI test
-#      run: ./scripts/tests/miri.sh
+    - name: Run MIRI test
+      run: ./scripts/tests/miri.sh
 
     - uses: actions/upload-artifact@v4
       with:

--- a/rmm/src/realm/mm/rtt.rs
+++ b/rmm/src/realm/mm/rtt.rs
@@ -83,12 +83,11 @@ pub fn create(rd: &Rd, rtt_addr: usize, ipa: usize, level: usize) -> Result<(), 
         }
         let pa: usize = parent_s2tte.addr_as_block(level - 1).into(); //XXX: check this again
         flags |= parent_s2tte.get_masked(S2TTE::MEMATTR | S2TTE::S2AP | S2TTE::SH);
-        if parent_s2tte.is_assigned_ram(level - 1) {
-            invalidate = Tlbi::LEAF(rd.id());
-        } else if !parent_s2tte.is_assigned_ns(level - 1) {
-            panic!("Unexpected s2tte value:{:X}", parent_s2tte.get());
-        }
         create_pgtbl_at(rtt_addr, flags, pa, map_size)?;
+
+        if parent_s2tte.is_assigned_ram(level - 1) || parent_s2tte.is_assigned_ns(level - 1) {
+            invalidate = Tlbi::LEAF(rd.id());
+        }
     }
 
     let parent_s2tte = rtt_addr as u64 | TABLE_TTE;

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -42,12 +42,10 @@ struct Exit {
     0x410 cntv_ctl: u64,
     0x418 cntv_cval: u64,
     0x500 ripas_base: u64,
-    0x508 ripas_size: u64,
+    0x508 ripas_top: u64,
     0x510 ripas_value: u8,
     0x600 imm: u16,
-    0x700 pmu_ovf: u64,
-    0x708 pmu_intr_en: u64,
-    0x710 pmu_cntr_en: u64,
+    0x700 pmu_ovf: u8,
     0x800 => @END,
 }
 );
@@ -131,9 +129,9 @@ impl Run {
         Ok(())
     }
 
-    pub fn set_ripas(&mut self, base: u64, size: u64, state: u8) {
+    pub fn set_ripas(&mut self, base: u64, top: u64, state: u8) {
         self.exit.ripas_base = base;
-        self.exit.ripas_size = size;
+        self.exit.ripas_top = top;
         self.exit.ripas_value = state;
     }
 
@@ -182,10 +180,7 @@ impl Run {
     }
 
     pub fn ripas(&self) -> (u64, u64) {
-        (
-            self.exit.ripas_base,
-            self.exit.ripas_base + self.exit.ripas_size,
-        )
+        (self.exit.ripas_base, self.exit.ripas_top)
     }
 }
 

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -73,10 +73,12 @@ impl Run {
         self.entry.gicv3_hcr
     }
 
+    #[cfg(fuzzing)]
     pub fn set_entry_flags(&mut self, flags: u64) {
         self.entry.flags = flags;
     }
 
+    #[cfg(fuzzing)]
     pub fn set_entry_gpr(&mut self, idx: usize, val: u64) -> Result<(), Error> {
         if idx >= NR_GPRS {
             error!("out of index: {}", idx);
@@ -86,10 +88,12 @@ impl Run {
         Ok(())
     }
 
+    #[cfg(fuzzing)]
     pub fn set_entry_gic_hcr(&mut self, val: u64) {
         self.entry.gicv3_hcr = val;
     }
 
+    #[cfg(fuzzing)]
     pub fn set_entry_gic_lrs(&mut self, src: &[u64], len: usize) {
         self.entry.gicv3_lrs.copy_from_slice(&src[..len])
     }

--- a/rmm/src/rmi/rec/run.rs
+++ b/rmm/src/rmi/rec/run.rs
@@ -71,31 +71,6 @@ impl Run {
         self.entry.gicv3_hcr
     }
 
-    #[cfg(fuzzing)]
-    pub fn set_entry_flags(&mut self, flags: u64) {
-        self.entry.flags = flags;
-    }
-
-    #[cfg(fuzzing)]
-    pub fn set_entry_gpr(&mut self, idx: usize, val: u64) -> Result<(), Error> {
-        if idx >= NR_GPRS {
-            error!("out of index: {}", idx);
-            return Err(Error::RmiErrorInput);
-        }
-        self.entry.gprs[idx] = val;
-        Ok(())
-    }
-
-    #[cfg(fuzzing)]
-    pub fn set_entry_gic_hcr(&mut self, val: u64) {
-        self.entry.gicv3_hcr = val;
-    }
-
-    #[cfg(fuzzing)]
-    pub fn set_entry_gic_lrs(&mut self, src: &[u64], len: usize) {
-        self.entry.gicv3_lrs.copy_from_slice(&src[..len])
-    }
-
     pub fn exit_gic_lrs_mut(&mut self) -> &mut [u64; 16] {
         &mut self.exit.gicv3_lrs
     }
@@ -181,6 +156,30 @@ impl Run {
 
     pub fn ripas(&self) -> (u64, u64) {
         (self.exit.ripas_base, self.exit.ripas_top)
+    }
+}
+
+#[cfg(fuzzing)]
+impl Run {
+    pub fn set_entry_flags(&mut self, flags: u64) {
+        self.entry.flags = flags;
+    }
+
+    pub fn set_entry_gpr(&mut self, idx: usize, val: u64) -> Result<(), Error> {
+        if idx >= NR_GPRS {
+            error!("out of index: {}", idx);
+            return Err(Error::RmiErrorInput);
+        }
+        self.entry.gprs[idx] = val;
+        Ok(())
+    }
+
+    pub fn set_entry_gic_hcr(&mut self, val: u64) {
+        self.entry.gicv3_hcr = val;
+    }
+
+    pub fn set_entry_gic_lrs(&mut self, src: &[u64], len: usize) {
+        self.entry.gicv3_lrs.copy_from_slice(&src[..len])
     }
 }
 

--- a/rmm/src/rmi/rtt.rs
+++ b/rmm/src/rmi/rtt.rs
@@ -642,7 +642,7 @@ mod test {
     // Source: https://github.com/ARM-software/cca-rmm-acs
     // Test Case: cmd_rtt_set_ripas
     // Covered RMIs: RTT_SET_RIPAS
-    // #[test] TODO: enable this test after fixing it
+    #[test]
     fn rmi_rtt_set_ripas_positive() {
         use crate::rmi::rec::run::Run;
         use crate::rsi::PSCI_CPU_ON;

--- a/rmm/src/rsi/mod.rs
+++ b/rmm/src/rsi/mod.rs
@@ -102,7 +102,9 @@ pub fn do_host_call(
         )
         .ok_or(Error::RmiErrorInput)?;
 
-    let mut host_call = assume_safe::<HostCall>(pa.into())?;
+    // page mapping result 'pa' is PAGE_SIZE aligned. Get hsot_call_ptr.
+    let host_call_ptr: usize = pa.as_usize() + ipa % crate::config::PAGE_SIZE;
+    let mut host_call = assume_safe::<HostCall>(host_call_ptr)?;
     let imm = host_call.imm();
 
     if rec.host_call_pending() {

--- a/rmm/src/rsi/ripas.rs
+++ b/rmm/src/rsi/ripas.rs
@@ -23,11 +23,13 @@ pub fn get_ripas_state(
 
     let base = get_reg(rec, 1)?;
     let top = get_reg(rec, 2)?;
+    // To prevent underflow when top is 0,
+    // check top <= base prior to addr_in_par() check
     if !is_granule_aligned(base)
         || !is_granule_aligned(top)
         || !rd.addr_in_par(base)
-        || !rd.addr_in_par(top - 1)
         || top <= base
+        || !rd.addr_in_par(top - 1)
     {
         if set_reg(rec, 0, rsi::ERROR_INPUT).is_err() {
             warn!("Unable to set register 0. rec: {:?}", rec);


### PR DESCRIPTION
1. Misimplementation against Spec is fixed
    - rtt: correct RMI_RTT_CREATE handler
        Remove the condition, !parent_s2tte.is_assigned_ns(level - 1), which is not in the success or failure conditions for RMI_RTT_CREATE in the RMMv1.0-rel0 spec. 
        (Fuzzer reached to this condition and triggered the assertion inside.)
   -  correct RMI_FEATURES miri test
       In case that the index input is zero, it should test if the output bits[42:63] is MBZ according to the spec.  (Current miri tests if bits[30:63] is MBZ)

2.  Use hard-coded feat_reg0 value for fuzzing. Otherwise, fuzzer crashes while it tries to initialize feat_reg0 with architecture specific values such as simd and gic.
     Add 'fuzzing' to the lines in  #[cfg(not(any(miri, test)))])

3. Add #cfg to conditionally build functions only used for the fuzz testing
