### PR TITLE
Send a digest of COSE pub_key instead of SEC1 for RMM_GET_PLAT_TOKEN

### DIFF
--- a/rmm/src/cose.rs
+++ b/rmm/src/cose.rs
@@ -1,0 +1,44 @@
+use alloc::{borrow::ToOwned, vec::Vec};
+use ciborium::ser;
+use coset::{iana, AsCborValue, CoseKeyBuilder};
+use ecdsa::elliptic_curve::sec1::ToEncodedPoint;
+
+// Convert SEC1 encoded EC2 public `key` to COSE/CBOR
+// Handles only p384 for now, others can be uncommented when needed
+pub fn ec_public_key_sec1_to_cose(key: &[u8]) -> Vec<u8> {
+    // let p256_sec1_len = 1 + 2 * 32;
+    let p384_sec1_len = 1 + 2 * 48;
+    // let p521_sec1_len = 1 + 2 * 66;
+
+    let key_cbor_value = match key.len() {
+        // n if n == p256_sec1_len => {
+        //     let pk = p256::PublicKey::from_sec1_bytes(key).expect("Failed to load p256 sec1 key");
+        //     let ep = pk.to_encoded_point(false);
+        //     let x = ep.x().unwrap().to_owned().to_vec();
+        //     let y = ep.y().unwrap().to_owned().to_vec();
+        //     let key = CoseKeyBuilder::new_ec2_pub_key(iana::EllipticCurve::P_256, x, y).build();
+        //     key.to_cbor_value().expect("Failed to encode p256 as CBOR")
+        // }
+        n if n == p384_sec1_len => {
+            let pk = p384::PublicKey::from_sec1_bytes(key).expect("Failed to load p384 sec1 key");
+            let ep = pk.to_encoded_point(false);
+            let x = ep.x().unwrap().to_owned().to_vec();
+            let y = ep.y().unwrap().to_owned().to_vec();
+            let key = CoseKeyBuilder::new_ec2_pub_key(iana::EllipticCurve::P_384, x, y).build();
+            key.to_cbor_value().expect("Failed to encode p384 as CBOR")
+        }
+        // n if n == p521_sec1_len => {
+        //     let pk = p521::PublicKey::from_sec1_bytes(key).expect("Failed to load p521 sec1 key");
+        //     let ep = pk.to_encoded_point(false);
+        //     let x = ep.x().unwrap().to_owned().to_vec();
+        //     let y = ep.y().unwrap().to_owned().to_vec();
+        //     let key = CoseKeyBuilder::new_ec2_pub_key(iana::EllipticCurve::P_521, x, y).build();
+        //     key.to_cbor_value().expect("Failed to encode p521 as CBOR")
+        // }
+        _ => panic!("Wrong sec1 key length"),
+    };
+
+    let mut key_cbor_bytes = Vec::new();
+    ser::into_writer(&key_cbor_value, &mut key_cbor_bytes).expect("Failed to serialize CBOR value");
+    key_cbor_bytes
+}

--- a/rmm/src/lib.rs
+++ b/rmm/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod allocator;
 pub mod asm;
 pub mod config;
+pub(crate) mod cose;
 pub mod cpu;
 pub(crate) mod event;
 pub mod exception;

--- a/rmm/src/rmm_el3/digest.rs
+++ b/rmm/src/rmm_el3/digest.rs
@@ -1,3 +1,4 @@
+use crate::cose;
 use alloc::vec::Vec;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 
@@ -32,9 +33,8 @@ fn calculate_hash(data: Vec<u8>, algo: HashAlgo) -> Vec<u8> {
 
 pub(super) fn get_realm_public_key_hash(key: Vec<u8>) -> Vec<u8> {
     let priv_dak = p384::SecretKey::from_slice(&key).unwrap();
+    let public_dak = priv_dak.public_key().to_sec1_bytes().to_vec();
+    let public_dak_cose = cose::ec_public_key_sec1_to_cose(&public_dak);
 
-    calculate_hash(
-        priv_dak.public_key().to_sec1_bytes().to_vec(),
-        HashAlgo::Sha256,
-    )
+    calculate_hash(public_dak_cose, HashAlgo::Sha256)
 }

--- a/rmm/src/rsi/attestation/mod.rs
+++ b/rmm/src/rsi/attestation/mod.rs
@@ -4,7 +4,6 @@ use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use ciborium::{ser, Value};
 use coset::{CoseSign1Builder, HeaderBuilder, TaggedCborSerializable};
 use ecdsa::signature::Signer;
-use p384::elliptic_curve::sec1::ToEncodedPoint;
 use tinyvec::ArrayVec;
 
 use crate::{
@@ -114,21 +113,14 @@ impl Attestation {
         let secret_key =
             p384::SecretKey::from_slice(&self.rak_priv).expect("Failed to import private RAK.");
 
-        let pub_key_enc_pt = secret_key.public_key().to_encoded_point(false);
-        let pub_key_x = pub_key_enc_pt
-            .x()
-            .expect("public_key X coordinate missing.");
-        let pub_key_y = pub_key_enc_pt
-            .y()
-            .expect("public_key Y coordinate missing.");
+        let public_key = secret_key.public_key().to_sec1_bytes().to_vec();
 
         let claims = RealmClaims::init(
             challenge,
             personalization_value,
             measurements,
             hash_algo_id,
-            pub_key_x,
-            pub_key_y,
+            &public_key,
             // TODO: should this value be stored somewhere else?
             String::from("sha-256"),
         );


### PR DESCRIPTION
Another change related to v1.0-rel0. Not sure it's according to spec but it's how TF-RMM does it now. See here:
https://github.com/TF-RMM/tf-rmm/commit/3aa34974bd21449e0be82f99e3e0c1888e67dfd6

Introduce one function to convert sec1 to cose for ec public keys and use it also in the attestation code for realm public key in the realm token.

Warning: it's very difficult to test this code now, for some reason unknown to me the raw serial port over FVP is even more unreliable than it was before. I have successfully tested it, but it's a pain to do so. On QEMU there are no such issues, but we don't have Islet-RMM fully working on QEMU yet (Linux/ACS) so testing here is limited. It will work successfully on QEMU when the update to Islet-RMM is fnished.