### PR TITLE
rec/simd: correct save_state()

### DIFF
--- a/rmm/src/exception/trap.rs
+++ b/rmm/src/exception/trap.rs
@@ -11,7 +11,6 @@ use crate::rec::simd;
 use crate::rec::Rec;
 
 use aarch64_cpu::registers::*;
-use armv9a::regs::CPTR_EL2;
 
 #[repr(u16)]
 #[derive(Debug, Copy, Clone)]
@@ -234,7 +233,6 @@ pub extern "C" fn handle_lower_exception(
                 }
                 // Note: To avoid being trapped from RMM's access to simd,
                 //       setting cptr_el2 should come prior to the context restoration.
-                CPTR_EL2.write(CPTR_EL2::TAM::SET);
                 simd::restore_state_lazy(rec);
                 rec.context.simd.is_used = true;
                 RET_TO_REC


### PR DESCRIPTION
    1. Fix save_state() for the fpu usage.
       Saving fpu state for realm was accidentally missing.

    2. Remove the redundant rec_simd.is_used check in save_state().

    3. No side effect, but remove the redundant CPTR_EL2 register
       configuration in the execption handler,
       which is handled in restore_state_lazy().

Sorry for the trouble. Previous tests for the SVE/SME implementation was done on FVP with sve and sme hw features enabled. Tests for fpu were only partially tested and missed the error.


Error report from Lukasz,
```bash
# To reproduce, simply run Islet:
$ ./scripts/fvp-cca --normal-world=linux --realm=linux --rmm=islet --rmm-log-level info

# On host:
> ./launch-realm.sh
 
# In the realm:
> cd /shared
> insmod rsi.ko
> ./bin/rsictl attest

#  The error:
> ./bin/rsictl attest
[  240.979467] rsi: device rsi open
[  240.988599] rsi: ioctl: attestation_token
[  240.988657] rsi: RSI attestation init, ret: RSI_SUCCESS, max_token_len: 4096
[  241.018486] rsi: More space is needed for the token, got: 64, need: 4096
[  241.037851] rsi: ioctl: attestation_token
[  241.037906] rsi: RSI attestation init, ret: RSI_SUCCESS, max_token_len: 4096
[  241.228054] rsi: RSI attestation continue, ret: RSI_SUCCESS, read: 2124
[  241.245422] rsi: device rsi released
Error: Ecdsa(signature::Error { source: None })
```
Now:
```bash
 ./rsictl attest
[ 1034.408266] rsi: device rsi open
[ 1034.438313] rsi: ioctl: attestation_token
[ 1034.438508] rsi: RSI attestation init, ret: RSI_SUCCESS, max_token_len: 4096
[ 1034.534270] rsi: More space is needed for the token, got: 64, need: 4096
[ 1034.595814] rsi: ioctl: attestation_token
[ 1034.596009] rsi: RSI attestation init, ret: RSI_SUCCESS, max_token_len: 4096
[ 1034.852841] rsi: RSI attestation continue, ret: RSI_SUCCESS, read: 2124
[ 1034.910027] rsi: device rsi released
== Realm Token cose:
Protected header               = Header { alg: Some(Assigned(ES384)), crit: [], content_type: None, key_id: [], iv: [], partial_iv: [], counter_signatures: [], rest: [] }
Unprotected header             = Header { alg: None, crit: [], content_type: None, key_id: [], iv: [], partial_iv: [], counter_signatures: [], rest: [] }
Signature                      = [4354d1dacb5af702e7e90919d1dcfde74902df1e5cc8dd32392b3ce13099719ff430c8a55c07a83734e421d89b3151d8056ec66cd5ab549b13f4f26eb16511a9213fd4be71834418c7f31c38d8bc5a3ddfc710a69f49380dd19a80ca3d42061f]
== End of Realm Token cose

== Realm Token:
Realm signing public key       (#44237) = [0476f988091be585ed41801aecfab858548c63057e16b0e676120bbd0d2f9c29e056c5d41a0130eb9c21517899dc23146b28e1b062bd3ea4b315fd219f1cbb528cb6e74ca49be16773734f61a1ca61031b2bbf3d918f2f94ffc4228e50919544ae]
Realm personalization value    (#44235) = [00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000]
Realm profile                  (#265) = "tag:arm.com,2023:realm#1.0.0"
Realm initial measurement      (#44238) = [610a6051d63cdbabf344629ba848f37be7318b8dca7279713fe7ea2846f2f664]
Realm challenge                (#10) = [5839fa09e79e15df2fe25c8f2bf2d06e9ec8602c6159328465a0266a50c9e99a52dd2be4a3f0ab7f1b51c673b1ad3c44d1508c952f5bad31acff4183f74a5bf2]
Realm hash algo id             (#44236) = "sha-256"
Realm public key hash algo id  (#44240) = "sha-256"
Realm measurements             (#44239)
  Realm extensible measurement   (#0) = [0000000000000000000000000000000000000000000000000000000000000000]
  Realm extensible measurement   (#1) = [0000000000000000000000000000000000000000000000000000000000000000]
  Realm extensible measurement   (#3) = [0000000000000000000000000000000000000000000000000000000000000000]
  Realm extensible measurement   (#2) = [0000000000000000000000000000000000000000000000000000000000000000]
== End of Realm Token.


== Platform Token cose:
Protected header               = Header { alg: Some(Assigned(ES384)), crit: [], content_type: None, key_id: [], iv: [], partial_iv: [], counter_signatures: [], rest: [] }
Unprotected header             = Header { alg: None, crit: [], content_type: None, key_id: [], iv: [], partial_iv: [], counter_signatures: [], rest: [] }
Signature                      = [31d04d52ccde952c1e32cba181885a40b8cc38e0528c1e89589807642aa5e3f2bc37f95374506bff4d2e4be7063c4d72419270c722e8d4d93ee8b6c9face3b43c9761a49941ab6f38ffdff496ad463b4cbfa11d83e23e31f7f62329de30c1cc8]
== End of Platform Token cose

== Platform Token:
Platform hash algo             (#2402) = "sha-256"
Profile                        (#265) = "tag:arm.com,2023:cca_platform#1.0.0"
Challange                      (#10) = [0d22e08a98469058486318283489bdb36f09dbefeb1864df433fa6e54ea2d711]
Configuration                  (#2401) = [cfcfcfcf]

    // I ommitted the details here.

    SW Type                        (#1) = "SOC_FW_CONFIG"
== End of Platform Token
```