### PR TITLE
Examples: use latest nightly rust for the cmd line tools

### DIFF
--- a/examples/app-provisioning/rust-toolchain
+++ b/examples/app-provisioning/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/examples/veraison/rust-toolchain
+++ b/examples/veraison/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
As in the title. The one forced by Islet itself is too old for some updated crates now.