### PR TITLE
Add restricted_mem option to lkvm while launching kvm-unit-tests

### DIFF
--- a/scripts/cca_base.py
+++ b/scripts/cca_base.py
@@ -330,6 +330,9 @@ class CCAPlatform(ABC):
         self.place_script_at_shared()
         if not no_kvm_unit_tests:
             self.run([f"cp", "-R", f"{OUT}/kvm-unit-tests", SHARED_PATH], cwd=ROOT)
+            # Copy run-realm-tests-islet that is adjusted to our Islet SW environment
+            # Note that this script is based on run-realm-tests from kvm-unit-tests repository
+            self.run(["cp", RUN_REALM_TESTS, f"{SHARED_PATH}/kvm-unit-tests/"], cwd=ROOT)
 
         if realm_ip and platform_ip and platform_tap_ip:
             # Use platform_ip for FVP_IP/QEMU_IP replacement

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -10,6 +10,7 @@ LAUNCH_REALM = os.path.join(SCRIPT, "fvp/launch-realm.sh")
 LAUNCH_REALM_DEBIAN = os.path.join(SCRIPT, "fvp/launch-realm-debian.sh")
 LAUNCH_REALM_METADATA = os.path.join(SCRIPT, "fvp/launch-realm-metadata.sh")
 TEST_REALM = os.path.join(SCRIPT, "fvp/test-realm.sh")
+RUN_REALM_TESTS = os.path.join(SCRIPT, "fvp/run-realm-tests-islet")
 CONFIGURE_NET = os.path.join(SCRIPT, "fvp/configure-net.sh")
 SET_REALM_IP = os.path.join(SCRIPT, "fvp/set-realm-ip.sh")
 

--- a/scripts/fvp/run-realm-tests-islet
+++ b/scripts/fvp/run-realm-tests-islet
@@ -1,0 +1,112 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023, Arm Ltd
+# All rights reserved
+#
+
+TASKSET=${TASKSET:-taskset}
+LKVM=${LKVM:-lkvm}
+ARGS="--realm --irqchip=gicv3 --console=serial --network mode=none --nodefaults --loglevel error --restricted_mem"
+PMU_ARGS="--pmu --pmu-counters=8"
+
+TESTDIR="."
+while getopts "d:" option; do
+	case "${option}" in
+		d) TESTDIR=${OPTARG};;
+		?)
+			exit 1
+			;;
+	esac
+done
+if [[ ! -d ${TESTDIR} ]]; then
+	echo "Invalid directory: ${TESTDIR}"
+	exit 1
+fi
+
+function set_all_cpu_except {
+	cpu_except=$1
+	cd /sys/devices/system/cpu
+	for c in $(find . -maxdepth 1 -type d -name "cpu[0-9]*")
+	do
+		if [ $(basename $c) != "cpu${cpu_except}" ]
+		then
+			echo $2 > $c/online
+		fi
+	done
+	cd -
+}
+
+function run_on_cpu0 {
+	# Check if we have TASKSET command available
+	$TASKSET --help &>/dev/null
+	no_taskset=$?
+	if [ $no_taskset -eq 0 ]
+	then
+		cmd_prefix="$TASKSET -c 0 "
+	else
+		set_all_cpu_except 0 0
+		cmd_prefix=""
+	fi
+
+	while read cmd
+	do
+		echo "Running on CPU0: ${cmd}"
+		${cmd_prefix} ${cmd}
+	done
+
+	if [ $no_taskset -ne 0 ]
+	then
+		set_all_cpu_except 0 1
+	fi
+}
+
+function run_tests {
+	DIR="$1"
+
+	$LKVM run $ARGS -c 2 -m 16 -k $DIR/selftest.flat -p "setup smp=2 mem=16"
+	$LKVM run $ARGS -c 2 -m 6 -k $DIR/selftest.flat -p "setup smp=2 sve-vl=128" --sve-max-vl=128
+	$LKVM run $ARGS -c 2 -m 6 -k $DIR/selftest.flat -p "setup smp=2 sve-vl=256" --sve-max-vl=256
+	$LKVM run $ARGS -c 1 -m 16 -k $DIR/selftest.flat -p "vectors-kernel"
+	$LKVM run $ARGS -c 1 -m 16 -k $DIR/selftest.flat -p "vectors-user"
+	$LKVM run $ARGS -c 4 -m 32 -k $DIR/selftest.flat -p "smp"
+	$LKVM run $ARGS -c 4 -m 32 -k $DIR/selftest.flat -p "memstress"
+
+	$LKVM run $ARGS -c 1 -m 32 -k $DIR/realm-ns-memory.flat
+
+	$LKVM run $ARGS -c 4 -m 32 -k $DIR/psci.flat
+
+	$LKVM run $ARGS -c 4 -m 32 -k $DIR/gic.flat -p "ipi"
+	$LKVM run $ARGS -c 4 -m 32 -k $DIR/gic.flat -p "active"
+
+	$LKVM run $ARGS -c 1 -m 16 -k $DIR/timer.flat
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "cycle-counter 0"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-event-introspection"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-event-counter-config"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-basic-event-count"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-mem-access"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-mem-access-reliability"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-sw-incr"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-chained-counters"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-chained-sw-incr"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-chain-promotion"
+	$LKVM run $ARGS $PMU_ARGS -c 2 -m 16 -k $DIR/pmu.flat -p "pmu-overflow-interrupt"
+
+	$LKVM run $ARGS -c 1 -m 16 -k $DIR/realm-rsi.flat -p "version"
+	$LKVM run $ARGS -c 1 -m 16 -k $DIR/realm-rsi.flat -p "host_call hvc"
+	$LKVM run $ARGS -c 1 -m 16 -k $DIR/realm-sea.flat
+
+	$LKVM run $ARGS -c 1 -m 24 -k $DIR/realm-attest.flat -p "attest"
+	$LKVM run $ARGS -c 2 -m 24 -k $DIR/realm-attest.flat -p "attest_smp"
+	$LKVM run $ARGS -c 1 -m 24 -k $DIR/realm-attest.flat -p "extend"
+	$LKVM run $ARGS -c 2 -m 24 -k $DIR/realm-attest.flat -p "extend_smp"
+	$LKVM run $ARGS -c 1 -m 24 -k $DIR/realm-attest.flat -p "extend_and_attest"
+	$LKVM run $ARGS -c 1 -m 24 -k $DIR/realm-attest.flat -p "measurement"
+
+	run_on_cpu0 << EOF
+$LKVM run $ARGS -c 4 -m 64 -k $DIR/fpu.flat
+$LKVM run $ARGS -c 4 -m 64 --sve-max-vl 128 -k $DIR/fpu.flat
+EOF
+
+}
+
+run_tests "${TESTDIR}"

--- a/scripts/fvp/test-realm.sh
+++ b/scripts/fvp/test-realm.sh
@@ -13,5 +13,5 @@ if [ "$1" == "attest" ]; then
 	LKVM=$LKVM $LKVM run $ARGS -c 1 -m 24 -k ./realm-attest.flat -p "extend_and_attest"
 	LKVM=$LKVM $LKVM run $ARGS -c 1 -m 24 -k ./realm-attest.flat -p "measurement"
 else
-	LKVM=$LKVM ./run-realm-tests
+	LKVM=$LKVM ./run-realm-tests-islet
 fi

--- a/scripts/fvp/test-realm.sh
+++ b/scripts/fvp/test-realm.sh
@@ -3,7 +3,7 @@
 set -e
 
 LKVM="/shared/lkvm"
-ARGS="--realm --irqchip=gicv3 --console=serial --network mode=none --nodefaults"
+ARGS="--realm --irqchip=gicv3 --console=serial --network mode=none --nodefaults --restricted_mem"
 
 cd kvm-unit-tests
 


### PR DESCRIPTION
The Islet/Arm CCA stack currently requires the use of Guest Private Memory. This is achieved by adding the --restricted_mem option to lkvm. Without it, the script for launching kvm-unit-tests fails to launch realms.

Here is the description on how to run the tests: https://github.com/islet-project/islet/blob/main/doc/getting-started/islet-how-to.md#testing-the-realm-features

> [!NOTE]
> Please test this PR using TF-RMM. For some reason Islet RMM fails to launch realms for kvm-unit-tests image.