### PR TITLE
Remove empty line in make_doc.sh script

### DIFF
--- a/scripts/make_doc.sh
+++ b/scripts/make_doc.sh
@@ -17,7 +17,6 @@ cd ${ROOT}/sdk
 cargo doc --lib --no-deps -p islet_sdk
 cp -R ${ROOT}/out/x86_64-unknown-linux-gnu/doc ${ROOT}/doc/app-doc
 
-
 # HES crate
 rm -rf ${ROOT}/doc/hes-doc
 cd ${ROOT}/hes


### PR DESCRIPTION
This was reported by shfmt tool used by the CI's rule checker.